### PR TITLE
fix: add timeout protection to lane execution (Issue #1)

### DIFF
--- a/src/renderer/src/lib/agent-runtime.ts
+++ b/src/renderer/src/lib/agent-runtime.ts
@@ -1012,9 +1012,11 @@ Return key findings only. End with "✓ Done".`;
 
               // EXECUTE via Lane Manager
               // It handles routing (Browser Serial vs Tab Serial vs API Parallel)
-              result = await laneManager.getLane(name, { tabId: this.options.tabId }).run(async () => {
+              const lane = laneManager.getLane(name, { tabId: this.options.tabId });
+              const timeoutMs = laneManager.getTimeoutForTool(name);
+              result = await lane.run(async () => {
                 return await executeToolCall(name, args);
-              }, this.options.signal);
+              }, timeoutMs, this.options.signal);
 
               return result;
 
@@ -1047,14 +1049,22 @@ Return key findings only. End with "✓ Done".`;
                   return executeCallWithSelfHealing(name, args, attempt + 1);
                 }
 
-                // Strategy 3: Timeout (Increase Timeout)
+                // Strategy 3: Lane Timeout (operation exceeded lane time limit)
+                if (errorStr.includes('Lane timeout')) {
+                  console.log(`[Self-Healing] Lane timeout for ${name} (attempt ${attempt}). Retrying in 2s...`);
+                  await new Promise(r => setTimeout(r, 2000));
+                  if (this.options.signal?.aborted) return { result: null, error: 'Aborted by user' };
+                  return executeCallWithSelfHealing(name, args, attempt + 1);
+                }
+
+                // Strategy 4: Tool-level Timeout (Increase Timeout)
                 if (errorStr.includes('Timeout') && args.timeout && typeof args.timeout === 'number') {
                   console.log(`[Self-Healing] Timeout in ${name}. Retrying with double timeout...`);
                   const newArgs = { ...args, timeout: args.timeout * 2 };
                   return executeCallWithSelfHealing(name, newArgs, attempt + 1);
                 }
 
-                // Strategy 4: Network Errors (Transient)
+                // Strategy 5: Network Errors (Transient)
                 if (errorStr.includes('net::ERR_') || errorStr.includes('ECONNREFUSED') || errorStr.includes('fetch failed')) {
                   console.log(`[Self-Healing] Network error in ${name}. Retrying in 2s...`);
                   await new Promise(r => setTimeout(r, 2000));
@@ -1062,7 +1072,7 @@ Return key findings only. End with "✓ Done".`;
                   return executeCallWithSelfHealing(name, args, attempt + 1);
                 }
 
-                // Strategy 5: Browser Context Lost (Transient)
+                // Strategy 6: Browser Context Lost (Transient)
                 if (errorStr.includes('Target closed') || errorStr.includes('Session closed') || errorStr.includes('Browser has been closed')) {
                   console.log(`[Self-Healing] Browser context lost in ${name}. Retrying in 1s...`);
                   await new Promise(r => setTimeout(r, 1000));
@@ -1070,14 +1080,80 @@ Return key findings only. End with "✓ Done".`;
                   return executeCallWithSelfHealing(name, args, attempt + 1);
                 }
 
-                // Strategy 6: Element Not Found (Retry with longer wait - page might be loading)
+                // Strategy 7: Element Not Found (Retry with longer wait - page might be loading)
                 if (errorStr.includes('Element not found') || errorStr.includes('waiting for selector') || errorStr.includes('No element matches')) {
                   console.log(`[Self-Healing] Element not found in ${name}. Retrying with longer wait...`);
                   const newArgs = { ...args, timeout: (args.timeout as number || 5000) * 1.5 };
                   return executeCallWithSelfHealing(name, newArgs, attempt + 1);
                 }
 
-                // Strategy 7: Navigation Timeout (Retry with longer timeout)
+                // Strategy 8: Navigation Timeout (Retry with longer timeout)
+                if (errorStr.includes('Navigation timeout') || errorStr.includes('page.goto')) {
+                  console.log(`[Self-Healing] Navigation timeout in ${name}. Retrying with extended timeout...`);
+                  const newArgs = { ...args, timeout: (args.timeout as number || 30000) * 1.5 };
+                  return executeCallWithSelfHealing(name, newArgs, attempt + 1);
+                }
+              }
+
+              // RECOVERY STRATEGIES (Max 2 Attempts)
+              if (attempt <= 2) {
+                // Early exit: don't retry if user already aborted
+                if (this.options.signal?.aborted) {
+                  return { result: null, error: 'Aborted by user' };
+                }
+
+                // Strategy 1: Context Destroyed (Navigation Race Condition)
+                if (errorStr.includes('Execution context was destroyed')) {
+                  console.log(`[Self-Healing] Context destroyed during ${name}. Waiting 1s and retrying...`);
+                  await new Promise(r => setTimeout(r, 1000));
+                  if (this.options.signal?.aborted) return { result: null, error: 'Aborted by user' };
+                  return executeCallWithSelfHealing(name, args, attempt + 1);
+                }
+
+                // Strategy 2: Stale Element (DOM Update)
+                if (errorStr.includes('Element is not attached') || errorStr.includes('Node is detached')) {
+                  console.log(`[Self-Healing] Stale element in ${name}. Retrying immediately...`);
+                  return executeCallWithSelfHealing(name, args, attempt + 1);
+                }
+
+                // Strategy 3: Lane Timeout (operation exceeded lane time limit)
+                if (errorStr.includes('Lane timeout')) {
+                  console.log(`[Self-Healing] Lane timeout for ${name} (attempt ${attempt}). Retrying in 2s...`);
+                  await new Promise(r => setTimeout(r, 2000));
+                  return executeCallWithSelfHealing(name, args, attempt + 1);
+                }
+
+                // Strategy 4: Tool-level Timeout (Increase Timeout)
+                if (errorStr.includes('Timeout') && args.timeout && typeof args.timeout === 'number') {
+                  console.log(`[Self-Healing] Timeout in ${name}. Retrying with double timeout...`);
+                  const newArgs = { ...args, timeout: args.timeout * 2 };
+                  return executeCallWithSelfHealing(name, newArgs, attempt + 1);
+                }
+
+                // Strategy 5: Network Errors (Transient)
+                if (errorStr.includes('net::ERR_') || errorStr.includes('ECONNREFUSED') || errorStr.includes('fetch failed')) {
+                  console.log(`[Self-Healing] Network error in ${name}. Retrying in 2s...`);
+                  await new Promise(r => setTimeout(r, 2000));
+                  if (this.options.signal?.aborted) return { result: null, error: 'Aborted by user' };
+                  return executeCallWithSelfHealing(name, args, attempt + 1);
+                }
+
+                // Strategy 6: Browser Context Lost (Transient)
+                if (errorStr.includes('Target closed') || errorStr.includes('Session closed') || errorStr.includes('Browser has been closed')) {
+                  console.log(`[Self-Healing] Browser context lost in ${name}. Retrying in 1s...`);
+                  await new Promise(r => setTimeout(r, 1000));
+                  if (this.options.signal?.aborted) return { result: null, error: 'Aborted by user' };
+                  return executeCallWithSelfHealing(name, args, attempt + 1);
+                }
+
+                // Strategy 7: Element Not Found (Retry with longer wait - page might be loading)
+                if (errorStr.includes('Element not found') || errorStr.includes('waiting for selector') || errorStr.includes('No element matches')) {
+                  console.log(`[Self-Healing] Element not found in ${name}. Retrying with longer wait...`);
+                  const newArgs = { ...args, timeout: (args.timeout as number || 5000) * 1.5 };
+                  return executeCallWithSelfHealing(name, newArgs, attempt + 1);
+                }
+
+                // Strategy 8: Navigation Timeout (Retry with longer timeout)
                 if (errorStr.includes('Navigation timeout') || errorStr.includes('page.goto')) {
                   console.log(`[Self-Healing] Navigation timeout in ${name}. Retrying with extended timeout...`);
                   const newArgs = { ...args, timeout: (args.timeout as number || 30000) * 1.5 };

--- a/src/renderer/src/lib/execution-lanes.ts
+++ b/src/renderer/src/lib/execution-lanes.ts
@@ -1,6 +1,32 @@
 
 import { STATEFUL_BROWSER_TOOLS, STATEFUL_FILE_TOOLS } from './client-tools';
 
+// ── Timeout Configuration ──────────────────────────────────────────────────────
+// Per-tool-type timeout limits (milliseconds)
+export const LANE_TIMEOUTS = {
+    DEFAULT: 60_000,              // 60s - general fallback
+    BROWSER_NAVIGATION: 120_000,  // 120s - navigate, goto (network-dependent)
+    BROWSER_ACTION: 30_000,       // 30s  - click, type, select, hover, etc.
+    BROWSER_SNAPSHOT: 15_000,     // 15s  - screenshot, snapshot (fast)
+    FILE_SYSTEM: 30_000,          // 30s  - file read/write
+} as const;
+
+/**
+ * Thrown when a lane task exceeds its allowed execution time.
+ * Distinguished from generic errors so self-healing can handle it appropriately.
+ */
+export class LaneTimeoutError extends Error {
+    public readonly timeoutMs: number;
+    public readonly laneId: string;
+
+    constructor(laneId: string, timeoutMs: number) {
+        super(`Lane timeout: operation in lane "${laneId}" exceeded ${timeoutMs}ms`);
+        this.name = 'LaneTimeoutError';
+        this.timeoutMs = timeoutMs;
+        this.laneId = laneId;
+    }
+}
+
 /**
  * Thrown when an operation is cancelled via an AbortSignal.
  */
@@ -30,13 +56,11 @@ export class LaneQueue {
      * Execute a task in this lane.
      * If concurrency limit is reached, it waits in queue.
      *
-     * @param task   The async work to execute.
-     * @param signal Optional AbortSignal.  If the signal fires while the task
-     *               is waiting in queue it is removed and rejected immediately.
-     *               If the signal is already aborted on entry, the task is
-     *               never enqueued.
+     * @param task      The async work to execute.
+     * @param timeoutMs Optional timeout in milliseconds.
+     * @param signal    Optional AbortSignal.
      */
-    async run<T>(task: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+    async run<T>(task: () => Promise<T>, timeoutMs?: number, signal?: AbortSignal): Promise<T> {
         // Fast path: already aborted before we even start
         if (signal?.aborted) {
             throw new LaneAbortError(this.id);
@@ -46,7 +70,28 @@ export class LaneQueue {
             const wrappedTask = async () => {
                 this.activeCount++;
                 try {
-                    const result = await task();
+                    let result: T;
+
+                    if (timeoutMs !== undefined && timeoutMs > 0) {
+                        // Race the real task against a timeout promise
+                        let timer: ReturnType<typeof setTimeout> | undefined;
+
+                        const timeoutPromise = new Promise<never>((_resolve, _reject) => {
+                            timer = setTimeout(() => {
+                                _reject(new LaneTimeoutError(this.id, timeoutMs));
+                            }, timeoutMs);
+                        });
+
+                        try {
+                            result = await Promise.race([task(), timeoutPromise]);
+                        } finally {
+                            // Always clear the timer to avoid leaks
+                            if (timer !== undefined) clearTimeout(timer);
+                        }
+                    } else {
+                        result = await task();
+                    }
+
                     resolve(result);
                 } catch (error) {
                     reject(error);
@@ -175,6 +220,41 @@ export class LaneManager {
             stats[id] = lane.stats;
         }
         return stats;
+    }
+
+    /**
+     * Returns the appropriate timeout (ms) for a given tool name.
+     * Navigation-style tools get a longer window; fast browser actions get a
+     * shorter one; file tools get their own bucket; everything else uses the
+     * default.
+     */
+    getTimeoutForTool(toolName: string): number {
+        // Navigation tools – network-dependent, need more time
+        const NAVIGATION_TOOLS = ['navigate', 'browser_navigate', 'playwright_navigate', 'goto'];
+        if (NAVIGATION_TOOLS.some(n => toolName.includes(n))) {
+            return LANE_TIMEOUTS.BROWSER_NAVIGATION;
+        }
+
+        // Snapshot / screenshot – should be fast
+        const SNAPSHOT_TOOLS = ['screenshot', 'browser_screenshot', 'browser_snapshot', 'snapshot'];
+        if (SNAPSHOT_TOOLS.some(n => toolName.includes(n))) {
+            return LANE_TIMEOUTS.BROWSER_SNAPSHOT;
+        }
+
+        // Other browser actions (click, type, hover, select, etc.)
+        const isBrowserTool = STATEFUL_BROWSER_TOOLS.includes(toolName) ||
+            toolName.startsWith('playwright_') ||
+            toolName.startsWith('browser_');
+        if (isBrowserTool) {
+            return LANE_TIMEOUTS.BROWSER_ACTION;
+        }
+
+        // File system tools
+        if (STATEFUL_FILE_TOOLS.includes(toolName)) {
+            return LANE_TIMEOUTS.FILE_SYSTEM;
+        }
+
+        return LANE_TIMEOUTS.DEFAULT;
     }
 }
 

--- a/src/renderer/src/lib/resource-lock.ts
+++ b/src/renderer/src/lib/resource-lock.ts
@@ -1,5 +1,5 @@
 
-import { laneManager } from './execution-lanes';
+import { laneManager, LANE_TIMEOUTS } from './execution-lanes';
 
 /**
  * SHIM: Redirects old lock calls to the new LaneManager.
@@ -9,7 +9,7 @@ import { laneManager } from './execution-lanes';
 export class Mutex {
     async runExclusive<T>(task: () => Promise<T> | T): Promise<T> {
         // Default to global browser lane for unidentified locks
-        return laneManager.getLane('navigate').run(async () => await task());
+        return laneManager.getLane('navigate').run(async () => await task(), LANE_TIMEOUTS.BROWSER_NAVIGATION);
     }
 
     // Legacy support - no-op or auto-release
@@ -20,14 +20,14 @@ export class Mutex {
 
 export const browserLock = {
     runExclusive: <T>(task: () => Promise<T> | T) => {
-        return laneManager.getLane('navigate').run(async () => await task());
+        return laneManager.getLane('navigate').run(async () => await task(), LANE_TIMEOUTS.BROWSER_NAVIGATION);
     }
 };
 
 export class KeyedMutex {
     async runExclusive<T>(key: string, task: () => Promise<T> | T): Promise<T> {
         // Redirect all file keys to the single FILESYSTEM lane
-        return laneManager.getLane('file_read').run(async () => await task());
+        return laneManager.getLane('file_read').run(async () => await task(), LANE_TIMEOUTS.FILE_SYSTEM);
     }
 }
 


### PR DESCRIPTION
## Summary

- **Issue:** `LaneQueue.run()` had no timeout protection — a single hung task (e.g., navigation to an unresponsive site) blocks the entire lane queue indefinitely.
- **Fix:** Added `Promise.race`-based timeout to `LaneQueue.run()` with per-tool-type timeout configuration.
- **Impact:** Hung operations now timeout and the queue advances, preventing indefinite blocking.

## Files Changed

| File | Change |
|------|--------|
| `execution-lanes.ts` | Added `LANE_TIMEOUTS` constants, `LaneTimeoutError` class, `timeoutMs` param to `run()`, `getTimeoutForTool()` |
| `agent-runtime.ts` | Pass tool-specific timeout to `lane.run()`, added self-healing Strategy 3 for lane timeout recovery |
| `resource-lock.ts` | Updated all `.run()` calls with appropriate timeouts |

## Timeout Configuration

| Tool Type | Timeout |
|-----------|---------|
| Browser Navigation | 120s |
| Browser Action (click, type) | 30s |
| Browser Snapshot/Screenshot | 15s |
| File System | 30s |
| Default | 60s |

---

## How to Reproduce the Issue (Before Fix)

1. Start the app and open the agent chat
2. Ask the agent to navigate to a very slow or unresponsive URL, e.g.: `"Navigate to https://httpstat.us/200?sleep=120000"` (a URL that delays 120 seconds)
3. While navigation is pending, ask the agent to do another browser action (e.g., `"Take a screenshot"`)
4. **Observe:** The screenshot request is queued in the `BROWSER_SERIAL` lane and blocks forever because the navigation never completes. The agent is fully frozen — no further tools can execute.
5. All subsequent browser tool calls (click, type, extract, etc.) are also queued and never run.
6. The only recovery is force-quitting the app.

**Root cause:** `LaneQueue.run()` at `execution-lanes.ts:23` awaits the task promise with no timeout — `const result = await task()` runs indefinitely.

## How to Verify the Fix

1. Check out the `fix/issue-1-lane-timeout` branch
2. Run `npm run build` — should complete with no errors
3. **Code review:**
   - Open `execution-lanes.ts` — confirm `LaneQueue.run()` now accepts a `timeoutMs` parameter and wraps the task with `Promise.race` against a timer
   - Confirm `LaneTimeoutError` is thrown when the timer fires, and `clearTimeout` runs in the `finally` block to avoid leaks
   - Confirm `LaneManager.getTimeoutForTool()` maps tool names to appropriate timeout buckets
4. **Functional verification:**
   - Ask the agent to navigate to a slow URL (e.g., `"Navigate to https://httpstat.us/200?sleep=180000"`)
   - After 120 seconds (BROWSER_NAVIGATION timeout), the operation should fail with a `Lane timeout` error
   - The self-healing wrapper (Strategy 3) catches the lane timeout and retries once after 2s
   - If the retry also times out, the error is returned to the LLM for recovery
   - Crucially, the lane queue advances — subsequent browser tools (screenshot, click, etc.) are no longer blocked
5. **Verify timeout values:**
   - `navigate` tool → should get 120s timeout
   - `browser_click` tool → should get 30s timeout
   - `browser_screenshot` → should get 15s timeout
   - `fs_read` → should get 30s timeout
   - Unknown tool → should get 60s default

Closes Issue #1 from `issues.md`