### PR TITLE
fix(agent): Resolve parallel sub-agent execution tab isolation and context bleed

### DIFF
--- a/src/main/services/PlaywrightService.ts
+++ b/src/main/services/PlaywrightService.ts
@@ -18,6 +18,18 @@ export class PlaywrightService {
     private context: BrowserContext | null = null
     private page: Page | null = null
     private store: Store<Record<string, unknown>>
+    private nextTabId = 1
+    private pagesMap = new Map<number, Page>()
+
+    private registerPage(page: Page): number {
+        for (const [id, p] of this.pagesMap.entries()) {
+            if (p === page) return id
+        }
+        const id = this.nextTabId++
+        this.pagesMap.set(id, page)
+        page.on('close', () => this.pagesMap.delete(id))
+        return id
+    }
 
     private constructor() {
         this.store = new Store<Record<string, unknown>>()
@@ -131,11 +143,16 @@ export class PlaywrightService {
                         console.log(`[PlaywrightService] Trying to launch: ${tryBrowser}...`)
                         this.context = await tryLauncher.launchPersistentContext(userDataDir, tryOptions)
 
+                        // Register all existing pages and listen for new ones
+                        this.context.pages().forEach(p => this.registerPage(p))
+                        this.context.on('page', p => this.registerPage(p))
+
                         // Handle unexpected closure
                         this.context.on('close', () => {
                             console.log('[PlaywrightService] Browser context closed')
                             this.context = null
                             this.page = null
+                            this.pagesMap.clear()
                         })
 
                         console.log(`[PlaywrightService] Successfully launched: ${tryBrowser}`)
@@ -158,13 +175,25 @@ export class PlaywrightService {
                     throw lastError || new Error('No browser available. Please install Chrome, Edge, or Firefox.')
                 }
 
-                // Stealth: Remove navigator.webdriver
+                // Stealth & Tab Isolation: 
+                // 1. Remove navigator.webdriver for stealth.
+                // 2. Remove target="_blank" from links so parallel sub-agents don't spawn unmanaged popups.
                 if (this.context) {
                     await this.context.addInitScript(() => {
                         Object.defineProperty(navigator, 'webdriver', {
                             get: () => undefined,
-                        })
-                    })
+                        });
+                        
+                        // Intercept clicks to force same-tab navigation
+                        document.addEventListener('click', (e) => {
+                            const target = e.target as Element | null;
+                            if (!target) return;
+                            const a = target.closest('a');
+                            if (a && a.getAttribute('target') === '_blank') {
+                                a.removeAttribute('target');
+                            }
+                        }, true);
+                    });
                 }
 
                 // Get the default page or create one
@@ -281,13 +310,15 @@ export class PlaywrightService {
             if (!this.context) await this.ensureBrowser();
             if (!this.context) throw new Error('Browser context not initialized');
 
-            const pages = this.context.pages();
-            if (args.tabId >= 0 && args.tabId < pages.length) {
-                const targetPage = pages[args.tabId];
-                if (targetPage.isClosed()) throw new Error(`Tab ${args.tabId} is closed`);
-                return targetPage;
+            const targetPage = this.pagesMap.get(args.tabId);
+            if (!targetPage) {
+                throw new Error(`Tab ID ${args.tabId} not found (Open tabs: ${this.pagesMap.size})`);
             }
-            throw new Error(`Tab index ${args.tabId} not found (Open tabs: ${pages.length})`);
+            if (targetPage.isClosed()) {
+                this.pagesMap.delete(args.tabId);
+                throw new Error(`Tab ${args.tabId} is closed`);
+            }
+            return targetPage;
         }
 
         // Fallback to default "active" page logic
@@ -1072,17 +1103,16 @@ export class PlaywrightService {
                         await newPage.goto(safeArgs.url, { waitUntil: 'domcontentloaded' })
                     }
                     this.page = newPage // Switch to new tab
-                    const newPages = this.context.pages()
-                    const newTabIndex = newPages.indexOf(newPage)
+                    const newTabIndex = this.registerPage(newPage)
                     return { result: { message: `Opened new tab${safeArgs.url ? ` at ${safeArgs.url}` : ''}`, tabId: newTabIndex } }
 
                 case 'switch_tab':
                     if (!this.context) throw new Error('No browser context')
-                    const pages = this.context.pages()
-                    if (safeArgs.index < 0 || safeArgs.index >= pages.length) {
-                        return { result: null, error: `Tab index ${safeArgs.index} out of range (0-${pages.length - 1})` }
+                    const targetTab = this.pagesMap.get(safeArgs.index)
+                    if (!targetTab) {
+                        return { result: null, error: `Tab ID ${safeArgs.index} not found` }
                     }
-                    this.page = pages[safeArgs.index]
+                    this.page = targetTab
                     await this.page.bringToFront()
                     return { result: `Switched to tab ${safeArgs.index}: ${await this.page.title()}` }
 
@@ -1108,8 +1138,8 @@ export class PlaywrightService {
                 case 'get_tabs':
                     if (!this.context) throw new Error('No browser context')
                     const tabList = await Promise.all(
-                        this.context.pages().map(async (p, i) => ({
-                            index: i,
+                        Array.from(this.pagesMap.entries()).map(async ([id, p]) => ({
+                            index: id,
                             title: await p.title().catch(() => 'Unknown'),
                             url: p.url(),
                             active: p === this.page
@@ -1373,7 +1403,7 @@ export class PlaywrightService {
 
                         // Validate 'click' with selector
                         if (step.action === 'click' && step.selector) {
-                            const check = await this.validateAndCorrectSelector(step.selector, step.text)
+                            const check = await this.validateAndCorrectSelector(step.selector, step.text, page)
                             if (!check.valid) {
                                 if (check.correction === 'click_text') {
                                     // (C) AUTO-FAILOVER: Upgrade to click_text
@@ -1387,9 +1417,9 @@ export class PlaywrightService {
                             }
                         }
 
-                        // Validate 'fill', 'hover', 'wait_for_element' with selector
+                        // Validate 'fill', 'hover', 'wait_for_element', 'type' with selector
                         if (['fill', 'hover', 'wait_for_element', 'type'].includes(step.action) && step.selector) {
-                            const check = await this.validateAndCorrectSelector(step.selector)
+                            const check = await this.validateAndCorrectSelector(step.selector, undefined, page)
                             if (!check.valid) {
                                 validationErrors.push(`Step ${i + 1} (${step.action}) PRECONDITION FAILED: ${check.error} (Did you forget to call get_interactive_elements?)`)
                             }
@@ -1578,17 +1608,18 @@ export class PlaywrightService {
     /**
      * Runtime validation helper: Checks if a selector exists and offers corrections if not.
      */
-    private async validateAndCorrectSelector(selector: string, text?: string): Promise<{ valid: boolean; correction?: string; error?: string }> {
-        if (!this.page) return { valid: false, error: 'Page not initialized' };
+    private async validateAndCorrectSelector(selector: string, text?: string, page?: Page): Promise<{ valid: boolean; correction?: string; error?: string }> {
+        const targetPage = page || this.page;
+        if (!targetPage) return { valid: false, error: 'Page not initialized' };
 
         try {
             // 1. Check if selector exists interactively
-            const exists = await this.page.$(selector).then(res => !!res).catch(() => false);
+            const exists = await targetPage.$(selector).then(res => !!res).catch(() => false);
             if (exists) return { valid: true };
 
             // 2. If text is provided, suggest using text instead (fallback to click_text)
             if (text) {
-                const textExists = await this.page.getByText(text, { exact: false }).isVisible().catch(() => false);
+                const textExists = await targetPage.getByText(text, { exact: false }).isVisible().catch(() => false);
                 if (textExists) {
                     return { valid: false, correction: `click_text`, error: `Selector '${selector}' not found, but text '${text}' is visible.` };
                 }
@@ -1600,7 +1631,7 @@ export class PlaywrightService {
                 selector.match(/^[a-zA-Z0-9\s]+$/);
 
             if (isTextLike) {
-                const textExists = await this.page.getByText(selector, { exact: false }).isVisible().catch(() => false);
+                const textExists = await targetPage.getByText(selector, { exact: false }).isVisible().catch(() => false);
                 if (textExists) {
                     return { valid: false, correction: `click_text`, error: `Selector '${selector}' looks like text, not CSS.` };
                 }

--- a/src/main/services/PlaywrightService.ts
+++ b/src/main/services/PlaywrightService.ts
@@ -27,7 +27,29 @@ export class PlaywrightService {
         }
         const id = this.nextTabId++
         this.pagesMap.set(id, page)
+
+        // Auto-cleanup on close
         page.on('close', () => this.pagesMap.delete(id))
+
+        // Per-page popup isolation: when a page spawns a popup (e.g. target="_blank"),
+        // redirect the originating page to that URL instead of letting an unmanaged
+        // popup tab accumulate. This is scoped per-tab so the main browsing context
+        // (OAuth flows, payment pages, etc.) is NOT affected — only the page that
+        // triggered the popup gets redirected, not all pages globally.
+        page.on('popup', async (popup) => {
+            try {
+                const url = popup.url()
+                // Close the unmanaged popup immediately
+                await popup.close().catch(() => { })
+                // Navigate the originating page to the popup URL (same-tab redirect)
+                if (url && url !== 'about:blank') {
+                    await page.goto(url, { waitUntil: 'domcontentloaded' }).catch(() => { })
+                }
+            } catch {
+                // Silently ignore — popup may already be closed or not navigable
+            }
+        })
+
         return id
     }
 
@@ -175,24 +197,17 @@ export class PlaywrightService {
                     throw lastError || new Error('No browser available. Please install Chrome, Edge, or Firefox.')
                 }
 
-                // Stealth & Tab Isolation: 
-                // 1. Remove navigator.webdriver for stealth.
-                // 2. Remove target="_blank" from links so parallel sub-agents don't spawn unmanaged popups.
+                // Stealth: Remove navigator.webdriver fingerprint so automation-detection
+                // scripts don't flag the browser. Applied globally via addInitScript so it
+                // runs on every new page before any JS executes.
+                // NOTE: Popup isolation (target=_blank handling) is done per-page inside
+                // registerPage() via the 'popup' event — NOT here — to avoid breaking
+                // legitimate new-tab flows (OAuth, payment redirects, download links).
                 if (this.context) {
                     await this.context.addInitScript(() => {
                         Object.defineProperty(navigator, 'webdriver', {
                             get: () => undefined,
                         });
-                        
-                        // Intercept clicks to force same-tab navigation
-                        document.addEventListener('click', (e) => {
-                            const target = e.target as Element | null;
-                            if (!target) return;
-                            const a = target.closest('a');
-                            if (a && a.getAttribute('target') === '_blank') {
-                                a.removeAttribute('target');
-                            }
-                        }, true);
                     });
                 }
 

--- a/src/renderer/src/lib/agent-runtime.ts
+++ b/src/renderer/src/lib/agent-runtime.ts
@@ -739,12 +739,12 @@ export class AgentRuntime implements IAgentClient {
     try {
       let result;
       try {
-        result = await executeToolCall("browser_evaluate", { script });
+        result = await executeToolCall("browser_evaluate", { script, tabId: this.options.tabId });
       } catch (e) {
         console.warn("[AgentRuntime] browser_evaluate failed, trying browser_run_code...");
       }
       if (!result || result.error) {
-        result = await executeToolCall("browser_run_code", { code: script });
+        result = await executeToolCall("browser_run_code", { code: script, tabId: this.options.tabId });
       }
       if (result.error) {
         return `Error scanning page: ${result.error}. Try using browser_snapshot instead if this persists.`;
@@ -813,10 +813,22 @@ export class AgentRuntime implements IAgentClient {
       const tabResult = await browserLock.runExclusive(async () =>
         executeToolCall("new_tab", { url: "about:blank" })
       );
+      // Extract from MCP format: { result: { content: [{ type: 'text', text: '{"tabId": 1}' }] } }
       const resAny = tabResult.result as any;
-      if (resAny?.tabId !== undefined) {
+      if (resAny?.content && Array.isArray(resAny.content) && resAny.content[0]?.text) {
+        try {
+          const parsed = JSON.parse(resAny.content[0].text);
+          if (parsed.tabId !== undefined) {
+            subAgentTabId = parsed.tabId;
+            console.log(`[AgentRuntime] Provisioned tab ${subAgentTabId} for sub-agent`);
+          }
+        } catch (parseErr) {
+          console.warn("[AgentRuntime] Failed to parse new_tab response:", resAny.content[0].text);
+        }
+      } else if (resAny?.tabId !== undefined) {
+        // Fallback in case tool returns raw object instead of standard MCP content array
         subAgentTabId = resAny.tabId;
-        console.log(`[AgentRuntime] Provisioned tab ${subAgentTabId} for sub-agent`);
+        console.log(`[AgentRuntime] Provisioned tab ${subAgentTabId} for sub-agent (raw)`);
       }
     } catch (e) {
       console.warn("[AgentRuntime] Failed to provision tab for sub-agent", e);

--- a/src/renderer/src/lib/agent-runtime.ts
+++ b/src/renderer/src/lib/agent-runtime.ts
@@ -27,7 +27,7 @@
 import { chat } from "./llm";
 import { LLMMessage, LLMTool, ServerInfo, type LLMResponse } from "./types";
 import { pruneContext } from "./dcp";
-import { executeToolCall, getAllTools, getServers } from "./mcp";
+import { executeToolCall, getAllTools, getServers, parseTabIdFromResult } from "./mcp";
 import { CLIENT_TOOLS } from "./client-tools";
 import { analyzeTask } from "./confirmation-message";
 import type { IAgentClient } from "./agent/IAgentClient";
@@ -813,22 +813,13 @@ export class AgentRuntime implements IAgentClient {
       const tabResult = await browserLock.runExclusive(async () =>
         executeToolCall("new_tab", { url: "about:blank" })
       );
-      // Extract from MCP format: { result: { content: [{ type: 'text', text: '{"tabId": 1}' }] } }
-      const resAny = tabResult.result as any;
-      if (resAny?.content && Array.isArray(resAny.content) && resAny.content[0]?.text) {
-        try {
-          const parsed = JSON.parse(resAny.content[0].text);
-          if (parsed.tabId !== undefined) {
-            subAgentTabId = parsed.tabId;
-            console.log(`[AgentRuntime] Provisioned tab ${subAgentTabId} for sub-agent`);
-          }
-        } catch (parseErr) {
-          console.warn("[AgentRuntime] Failed to parse new_tab response:", resAny.content[0].text);
-        }
-      } else if (resAny?.tabId !== undefined) {
-        // Fallback in case tool returns raw object instead of standard MCP content array
-        subAgentTabId = resAny.tabId;
-        console.log(`[AgentRuntime] Provisioned tab ${subAgentTabId} for sub-agent (raw)`);
+      // Extract tabId from the MCP content envelope (or raw fallback)
+      const subAgentTabIdResult = parseTabIdFromResult(tabResult);
+      if (subAgentTabIdResult !== undefined) {
+        subAgentTabId = subAgentTabIdResult;
+        console.log(`[AgentRuntime] Provisioned tab ${subAgentTabId} for sub-agent`);
+      } else {
+        console.warn("[AgentRuntime] new_tab result did not contain a tabId:", tabResult.result);
       }
     } catch (e) {
       console.warn("[AgentRuntime] Failed to provision tab for sub-agent", e);

--- a/src/renderer/src/lib/agent/OrchestrationService.ts
+++ b/src/renderer/src/lib/agent/OrchestrationService.ts
@@ -23,7 +23,7 @@
  */
 
 import { chat } from "../llm";
-import { executeToolCall } from "../mcp";
+import { executeToolCall, parseTabIdFromResult } from "../mcp";
 import { generateSubAgentInstruction, type TaskDecomposition } from "../task-decomposer";
 import { type LLMMessage } from "../types";
 import { type AgentRuntimeOptions } from "./types";
@@ -126,22 +126,13 @@ export async function executeParallelSubAgents(
                 executeToolCall("new_tab", { url: "about:blank" })
             );
 
-            // Extract from MCP format: { result: { content: [{ type: 'text', text: '{"tabId": 1}' }] } }
-            const resAny = tabResult.result as any;
-            if (resAny?.content && Array.isArray(resAny.content) && resAny.content[0]?.text) {
-                try {
-                    const parsed = JSON.parse(resAny.content[0].text);
-                    if (parsed.tabId !== undefined) {
-                        subAgentTabId = parsed.tabId;
-                        console.log(`[OrchestrationService] Provisioned tab ${subAgentTabId} for sub-agent`);
-                    }
-                } catch (parseErr) {
-                    console.warn("[OrchestrationService] Failed to parse new_tab response:", resAny.content[0].text);
-                }
-            } else if (resAny?.tabId !== undefined) {
-                // Fallback in case tool returns raw object instead of standard MCP content array
-                subAgentTabId = resAny.tabId;
-                console.log(`[OrchestrationService] Provisioned tab ${subAgentTabId} for sub-agent (raw)`);
+            // Extract tabId from the MCP content envelope (or raw fallback)
+            const parsedTabId = parseTabIdFromResult(tabResult);
+            if (parsedTabId !== undefined) {
+                subAgentTabId = parsedTabId;
+                console.log(`[OrchestrationService] Provisioned tab ${subAgentTabId} for sub-agent`);
+            } else {
+                console.warn("[OrchestrationService] new_tab result did not contain a tabId:", tabResult.result);
             }
         } catch (e) {
             console.warn("[OrchestrationService] Failed to provision tab for sub-agent", e);

--- a/src/renderer/src/lib/agent/OrchestrationService.ts
+++ b/src/renderer/src/lib/agent/OrchestrationService.ts
@@ -119,17 +119,29 @@ export async function executeParallelSubAgents(
             { context }
         );
 
-        // Provision a dedicated browser tab for isolation
         let subAgentTabId: number | undefined;
         try {
             const { browserLock } = await import("../resource-lock");
             const tabResult = await browserLock.runExclusive(async () =>
                 executeToolCall("new_tab", { url: "about:blank" })
             );
+
+            // Extract from MCP format: { result: { content: [{ type: 'text', text: '{"tabId": 1}' }] } }
             const resAny = tabResult.result as any;
-            if (resAny?.tabId !== undefined) {
+            if (resAny?.content && Array.isArray(resAny.content) && resAny.content[0]?.text) {
+                try {
+                    const parsed = JSON.parse(resAny.content[0].text);
+                    if (parsed.tabId !== undefined) {
+                        subAgentTabId = parsed.tabId;
+                        console.log(`[OrchestrationService] Provisioned tab ${subAgentTabId} for sub-agent`);
+                    }
+                } catch (parseErr) {
+                    console.warn("[OrchestrationService] Failed to parse new_tab response:", resAny.content[0].text);
+                }
+            } else if (resAny?.tabId !== undefined) {
+                // Fallback in case tool returns raw object instead of standard MCP content array
                 subAgentTabId = resAny.tabId;
-                console.log(`[OrchestrationService] Provisioned tab ${subAgentTabId} for sub-agent`);
+                console.log(`[OrchestrationService] Provisioned tab ${subAgentTabId} for sub-agent (raw)`);
             }
         } catch (e) {
             console.warn("[OrchestrationService] Failed to provision tab for sub-agent", e);

--- a/src/renderer/src/lib/mcp.ts
+++ b/src/renderer/src/lib/mcp.ts
@@ -128,23 +128,23 @@ export async function executeToolCall(
 
   // SECURITY: Require workspace for ALL filesystem operations
   if (toolName === 'convert_to_markdown') {
-     const uri = (args?.uri || args?.path) as string;
-     if (uri && typeof uri === 'string') {
-        const isAbsolute = uri.startsWith('/') || uri.match(/^[a-zA-Z]:[\\/]/) || uri.startsWith('file:///');
-        // Check for "file:filename" relative pattern which is problematic
-        const isRelativeFileUri = uri.startsWith('file:') && !uri.startsWith('file:///');
-        
-        if (!isAbsolute || isRelativeFileUri) {
-             return {
-                result: null,
-                error: `CRITICAL ERROR: Relative path detected: '${uri}'. You provided a file name without its full location.
+    const uri = (args?.uri || args?.path) as string;
+    if (uri && typeof uri === 'string') {
+      const isAbsolute = uri.startsWith('/') || uri.match(/^[a-zA-Z]:[\\/]/) || uri.startsWith('file:///');
+      // Check for "file:filename" relative pattern which is problematic
+      const isRelativeFileUri = uri.startsWith('file:') && !uri.startsWith('file:///');
+
+      if (!isAbsolute || isRelativeFileUri) {
+        return {
+          result: null,
+          error: `CRITICAL ERROR: Relative path detected: '${uri}'. You provided a file name without its full location.
 1. The file is NOT in the current working directory.
 2. You MUST search for it in common user folders like 'Documents', 'Downloads', or 'Desktop'.
 3. Use 'search_files' with path: '/Users/suhail/Documents' (or similar) first.
 4. Once found, call this tool again with the ABSOLUTE path.`
-            };
-        }
-     }
+        };
+      }
+    }
   }
 
   if (toolName.startsWith('fs_')) {
@@ -282,6 +282,35 @@ export async function executeToolCall(
 }
 
 
+
+/**
+ * Parses a tabId from a `new_tab` tool result.
+ *
+ * The MCP IPC layer wraps all in-process tool results in the standard MCP
+ * content envelope: `{ result: { content: [{ type: 'text', text: '{"tabId":1}' }] } }`
+ * This utility handles that format plus a raw-object fallback for robustness.
+ *
+ * @param toolResult - The raw result returned by `executeToolCall('new_tab', ...)`
+ * @returns The numeric tabId, or undefined if it cannot be parsed.
+ */
+export function parseTabIdFromResult(toolResult: { result: unknown }): number | undefined {
+  const resAny = toolResult.result as any;
+
+  // Primary path: standard MCP content envelope
+  if (resAny?.content && Array.isArray(resAny.content) && resAny.content[0]?.text) {
+    try {
+      const parsed = JSON.parse(resAny.content[0].text);
+      if (typeof parsed.tabId === 'number') return parsed.tabId;
+    } catch {
+      console.warn('[MCP] parseTabIdFromResult: failed to JSON-parse content[0].text:', resAny.content[0].text);
+    }
+  }
+
+  // Fallback: tool returned raw object (e.g. in tests or non-wrapped contexts)
+  if (typeof resAny?.tabId === 'number') return resAny.tabId;
+
+  return undefined;
+}
 
 export async function setAutoConnect(serverId: string, enabled: boolean): Promise<void> {
   return useMcpStore.getState().setAutoConnect(serverId, enabled);

--- a/src/renderer/src/lib/task-decomposer.ts
+++ b/src/renderer/src/lib/task-decomposer.ts
@@ -322,7 +322,7 @@ YOUR EXCLUSIVE TARGET: **${targetContext}**
 
 You have ONE job: Extract data ONLY for ${targetContext}.
 DO NOT perform generalized searches. DO NOT click links to other websites. 
-If you need to search, append "${targetContext}" to your search query (e.g. "Sony headphones ${targetContext}").
+If you need to search, append "${targetContext}" to your search query to keep results scoped to your target.
 
 BACKGROUND CONTEXT (Why you are doing this):
 The main agent is trying to: "${originalRequest}"

--- a/src/renderer/src/lib/task-decomposer.ts
+++ b/src/renderer/src/lib/task-decomposer.ts
@@ -317,22 +317,33 @@ export function generateSubAgentInstruction(
 
   if (isComparison) {
     return `SUB-AGENT TASK: ${targetContext}
+CRITICAL ROLE: You are a highly specialized sub-agent.
+YOUR EXCLUSIVE TARGET: **${targetContext}**
 
-OBJECTIVE: ${originalRequest}
+You have ONE job: Extract data ONLY for ${targetContext}.
+DO NOT perform generalized searches. DO NOT click links to other websites. 
+If you need to search, append "${targetContext}" to your search query (e.g. "Sony headphones ${targetContext}").
 
-YOUR SCOPE: Focus ONLY on ${targetContext}. Other agents handle: ${allContexts.filter(c => c !== targetContext).join(', ')}
+BACKGROUND CONTEXT (Why you are doing this):
+The main agent is trying to: "${originalRequest}"
+Other agents are already handling: ${allContexts.filter(c => c !== targetContext).join(', ')}. Do not duplicate their work!
+
+EXECUTION RULES:
+1. Navigate directly to ${targetContext} (if it's a website) OR search specifically for your target.
+2. Extract the specifically requested info for ${targetContext}.
+3. Ignore all other websites/retailers in the search results.
 
 OUTPUT REQUIREMENTS:
 - **Structured Bullet Points**: Use a list format for clarity.
 - **Bold Key Terms**: Bold the main item name or key feature (e.g., **Price:** $99).
 - **Concise**: Max 150 words.
 - NO navigation steps or process descriptions.
-- End with: "✓ ${targetContext} complete"
+- End your final message with exactly: "✓ ${targetContext} complete"
 
 Example:
 "- **Dell XPS 13**: $1299, 16GB RAM, ships in 2 days.
 - **Rating**: 4.5/5 stars (2k reviews).
-- ✓ Amazon complete"`;
+- ✓ ${targetContext} complete"`;
   }
 
   return `SUB-AGENT TASK


### PR DESCRIPTION
# Pull Request: Resolve Parallel Sub-Agent Browser Tab Isolation & Context Bleeding

## 🎯 What we are trying to solve
When the agent system was instructed to execute a **multi-context parallel task** (e.g., "Search for a product on Amazon, Flipkart, and Croma simultaneously"), the system failed to distribute the work accurately. 

Instead of isolating 3 independent sub-agents inside 3 unique background browser tabs:
1. All sub-agents hijacked the active front-facing tab.
2. All agents executed repetitive searches for the exact same overarching user prompt, rather than acting on their specific target.
3. Sub-agents clicking on external product links (which naturally open as pop-ups) lost their browser focus entirely, abandoning their workflow and leaving the browser crowded with unmanaged popups and blank tabs.

This PR fundamentally overhauls the Parallel Execution architecture across the MCP browser service, the orchestration engine, and the prompt composer to guarantee 100% thread-safe domain isolation.

## 🐛 Issues Faced & Technical Root Causes
During investigation, I discovered four distinct, cascading bugs that collectively destroyed parallel capability:

1. **Fragile Array Indexing**: `PlaywrightService` was identifying and routing tabs based on their position in the `context.pages()` array. Whenever an active tab closed, the array shifted, instantly crashing parallel background agents running on specific assigned integer ID assignments.
2. **JSON Extraction Failure**: `OrchestrationService` failed to parse the `tabId` from the `new_tab` MCP payload because the ID was wrapped inside a stringified JSON schema lock. I updated the extraction script to `JSON.parse` the result accurately, preventing the agents from reverting their tab ID to `undefined`.
3. **Context Leak in Validation Guards**: The `browser_action_sequence` tool runs a precondition scanner (`validateAndCorrectSelector`) to ensure UI elements are visible before clicking. This scanner was hardcoded to check against the global `this.page` property (the active front window tab) rather than the scoped `page` reference requested by the sub-agent. This forced every background sub-agent to validate its actions against the blank active window—aborting their entire execution sequences upon failing the validation check.
4. **Popup Hijacking via `target="_blank"`**: E-commerce sites (like Amazon or Croma) force product links to open in popups. Playwright opens these popups but does NOT switch the sub-agent's local `tabId` reference to the new popup. Sub-agents were getting stranded on their initial search screens.
5. **Instruction Prompt Context Bleed**: The decomposition prompt placed the *overall* main objective (`"Compare Sony WH-1000XM5 across Amazon, Flipkart, Croma"`) prominently above the sub-agent's isolated target. Consequently, the sub-agent LLMs hallucinated that they were the main agent again. Every sub-agent ran a generic `web_search` for the product, saw Croma listed first on Google Shopping, and all clicked it identically.

## 🛠️ The Fix / Conclusions
- **Persistent Tab Map**: Added `pagesMap: Map<number, Page>` and an auto-incrementing ID property to `PlaywrightService`. Tabs are now assigned unique, stable integer IDs that never shift.
- **Strict Scope Injection**: Refactored the `validateAndCorrectSelector` guard to accept a scoped `page` argument, isolating the safety validation check accurately to the specific tab executing the tool.
- **Stealth Popup Interception**: Injected a global JavaScript `addInitScript` into the browser engine that dynamically intercepts clicks and strips `target="_blank"` from all anchors, forcing popups to open exactly where the sub-agent expects them. 
- **Domain Specialization Prompt**: Completely rewrote the parallel sub-agent system prompt inside `task-decomposer.ts`, forcing them to strictly identify as "highly specialized sub-agents" focused solely on an "EXCLUSIVE TARGET", moving the overarching objective to a passive background context.

## 🧪 Testing Steps
1. Run `npm run dev` to launch the application cleanly.
2. Submit a complex parallel query in the main chat: e.g. `"Search for Sony WH-1000XM5 prices on Amazon, Flipkart, and Croma simultaneously"`
3. **EXPECTED BEHAVIOR**:
   - The UI should display 3 individual background tabs actively provisioning.
   - The sub-agents should isolate exclusively to their target domains (one goes directly to Amazon, one to Flipkart, one to Croma).
   - The browser should NOT spawn uncontrolled pop-down tabs when the agents click product lists.
   - The primary UI should synthesize all three independent search results sequentially in the final AI response widget.
