### PR TITLE
feat: Browsing Speed Optimization (Inline Content & MarkItDown)

### DIFF
--- a/src/main/services/PlaywrightService.ts
+++ b/src/main/services/PlaywrightService.ts
@@ -682,7 +682,39 @@ export class PlaywrightService {
                     if (navError) return { result: null, error: navError }
                     try {
                         await page.goto(safeArgs.url, { waitUntil: 'domcontentloaded' })
-                        return { result: `Navigated to ${safeArgs.url}` }
+
+                        // ── AUTO-EXTRACT: Return page context inline ──────────────
+                        // Eliminates the need for separate get_state/get_interactive_elements calls.
+                        // The LLM gets page content + CTAs in one shot.
+                        const navTitle = await page.title()
+                        const navPageText = await page.evaluate(() => {
+                            return document.body?.innerText?.substring(0, 2000) || ''
+                        }).catch(() => '')
+                        const navElements = await page.evaluate(() => {
+                            const sels = 'a[href],button,input,textarea,select,[role="button"],[role="link"]'
+                            const els = document.querySelectorAll(sels)
+                            const list: string[] = []
+                            let i = 1
+                            els.forEach(el => {
+                                const r = el.getBoundingClientRect()
+                                if (r.width > 0 && r.height > 0 && i <= 15) {
+                                    const t = ((el as HTMLElement).innerText ||
+                                        (el as HTMLInputElement).placeholder || '').substring(0, 40).trim()
+                                    const tag = el.tagName.toLowerCase()
+                                    let sel = tag
+                                    if (el.id) sel = `#${el.id}`
+                                    else if (el.className && typeof el.className === 'string') sel = `.${el.className.split(' ')[0]}`
+                                    list.push(`[${i++}] ${tag}: "${t || '(empty)'}" → ${sel}`)
+                                }
+                            })
+                            return list
+                        }).catch(() => [] as string[])
+
+                        return {
+                            result: `Page: ${navTitle}\nURL: ${page.url()}\n\n` +
+                                `--- Page Content (preview) ---\n${navPageText}\n\n` +
+                                `--- Interactive Elements (${navElements.length}) ---\n${navElements.join('\n')}`
+                        }
                     } catch (e) {
                         // AUTO-FALLBACK: Google Search
                         // If we failed to resolve the name, it might be a typo or a non-url search query
@@ -1467,12 +1499,35 @@ export class PlaywrightService {
                         ? pageText.substring(0, MAX_CHARS) + '\n\n... (truncated)'
                         : pageText
 
+                    // ── Extract clickable result links ──────────────────────
+                    // Gives the LLM direct hrefs to click without needing get_interactive_elements
+                    const searchLinks = await page.evaluate(() => {
+                        const links = document.querySelectorAll('a[href]')
+                        const list: string[] = []
+                        let i = 1
+                        links.forEach(link => {
+                            const r = link.getBoundingClientRect()
+                            const t = (link as HTMLElement).innerText?.substring(0, 60).trim()
+                            const href = (link as HTMLAnchorElement).href
+                            // Filter to meaningful result links (skip nav, ads footers)
+                            if (r.width > 0 && r.height > 0 && t && t.length > 5 && i <= 10 &&
+                                href.startsWith('http') && !href.includes('google.com/search') &&
+                                !href.includes('accounts.google') && !href.includes('support.google')) {
+                                list.push(`[${i++}] "${t}" → ${href}`)
+                            }
+                        })
+                        return list
+                    }).catch(() => [] as string[])
+
                     const pageTitle = await page.title()
                     return {
                         result: `Search results for "${query}" (via ${engine}):\n` +
                             `Page: ${pageTitle}\n` +
                             `URL: ${page.url()}\n\n` +
-                            trimmedText
+                            trimmedText +
+                            (searchLinks.length > 0
+                                ? `\n\n--- Clickable Result Links (${searchLinks.length}) ---\n${searchLinks.join('\n')}`
+                                : '')
                     }
                 }
 

--- a/src/renderer/src/lib/agent/ToolExecutionService.ts
+++ b/src/renderer/src/lib/agent/ToolExecutionService.ts
@@ -365,7 +365,7 @@ export function formatToolResult(
 
         if (errorMsg.includes("not found") || errorMsg.includes("Timeout")) {
             recoveryHint =
-                "\n\n💡 **Recovery Tip**: The element was not found. Try:\n1. Take a screenshot to see the current page state.\n2. Use `get_state` to list available elements.\n3. Use a different, more general selector (e.g., text-based like `text=\"Submit\"`).\n4. The page might have changed—verify the URL is correct.";
+                "\n\n💡 **Recovery Tip**: Try:\n1. `convert_to_markdown(uri=\"current_page_url\")` for fast content reading (no browser needed)\n2. `get_interactive_elements()` to find clickable elements\n3. `screenshot()` to see the current page state\n4. Use a text-based selector like `text=\"Submit\"` instead";
         } else if (errorMsg.includes("not visible") || errorMsg.includes("hidden")) {
             recoveryHint =
                 "\n\n💡 **Recovery Tip**: The element exists but is hidden. Try:\n1. Scroll the page first (`scroll`).\n2. Wait for animations to complete (`wait`).\n3. Check if a modal or popup is blocking.";

--- a/src/renderer/src/lib/llm.ts
+++ b/src/renderer/src/lib/llm.ts
@@ -1280,17 +1280,17 @@ ${dynamicRules ? `\n# TASK-SPECIFIC PROTOCOLS\n${dynamicRules}\n` : ''}
 
 # EFFICIENT DISCOVERY & SELECTOR PROTOCOL (CRITICAL)
 - **NO GUESSING**: Never invent selectors like ".product-item" or "#results".
-- **DISCOVERY HIERARCHY**:
-  1. \`get_interactive_elements\` (LOWEST TOKENS): Use this FIRST to see what is clickable (buttons, inputs, links).
-  2. \`scan_page_accessibility\` (LOW TOKENS): Use to read content structure and find text.
-  3. \`get_state(mode="fast")\` (MEDIUM TOKENS): Use if you need a broader text overview.
-  4. \`get_state(mode="vision")\` (HIGH TOKENS): Use *only* if visual layout is confusing or standard tools fail.
+- **NAVIGATE & WEB_SEARCH RETURN CONTENT**: These tools already return page text + interactive elements.
+  Use that output FIRST before calling any additional discovery tools.
+- **READ-ONLY FAST PATH**: For tasks that ONLY require reading a webpage (research, summarizing articles),
+  use \`convert_to_markdown(uri="https://...")\` instead of browser navigation — it's 10x faster, no browser needed.
+  Use Playwright navigate only when you need to INTERACT with the page (click, fill, scroll).
+- **ESCALATION** (only if navigate output isn't enough):
+  1. \`get_interactive_elements\` (LOW TOKENS): More elements beyond the top 15 from navigate.
+  2. \`get_state(mode="fast")\` (MEDIUM TOKENS): Broader element overview.
+  3. \`get_state(mode="vision")\` (HIGH TOKENS): Use *only* as last resort when visual layout is confusing.
 
-- **DYNAMIC SITES**: Amazon, Google, etc. use randomized classes (e.g. "s-result-item-XyZ"). You cannot guess these. You MUST inspect them.
-- **INSPECT BEFORE INTERACT**: 
-  1. Navigate
-  2. Inspect (get_interactive_elements)
-  3. Interact (using discovered selectors)
+- **DYNAMIC SITES**: Amazon, Google, etc. use randomized classes. You MUST use the selectors from navigate output or get_interactive_elements — never guess.
 
 # ERROR HANDLING
 - Element not found? → screenshot() to see actual page, then use correct selector

--- a/src/renderer/src/lib/prompt-library.ts
+++ b/src/renderer/src/lib/prompt-library.ts
@@ -16,19 +16,23 @@ export const PROMPTS = {
    //Research / Information Gathering (Refined with Anthropic & Cursor patterns)
    RESEARCH: `
 # RESEARCH & BROWSING PROTOCOLS
-1. **Autonomous Search Strategy**: 
+1. **Speed & Efficiency**:
+   - **READ-ONLY pages**: Use \`convert_to_markdown(uri="https://...")\` to fetch content — 10x faster than browser navigation.
+   - **Interactive pages**: Use \`navigate\` (it returns page content + CTAs inline — no extra tool calls needed).
+   - **Search**: Use \`web_search\` (returns results + clickable links in one shot).
+2. **Autonomous Search Strategy**: 
    - **Broad First**: Start with high-level queries to understand the landscape.
    - **Specific Second**: Narrow down with specific terms (e.g., "site:reddit.com", "v2 vs v3").
    - **Self-Driven**: If first search unclear, try different phrasings. Don't ask user immediately.
    - **Verification**: If you find a claim, verify it on a second independent source.
-2. **Context Maximization**:
+3. **Context Maximization**:
    - Do NOT just read the first result. Check at least 3 varied sources.
    - TRACE citations back to their primary source (e.g., official docs > blog posts).
    - **Follow Links**: If a source mentions something relevant, visit it autonomously.
-3. **Citation Rules**:
+4. **Citation Rules**:
    - EVERY claim must be supported by a source.
    - Explicitly mention the source URL/Name.
-4. **Deep Dives**: 
+5. **Deep Dives**: 
    - If the query is broad, provide a high-level summary first.
    - Ask the user if they want to "go deeper" into specific aspects.
 `.trim(),
@@ -92,6 +96,8 @@ export const PROMPTS = {
    - **Verification**: Check the result. Did the page change? Did the error appear?
    - **Correction**: If it failed, try a DIFFERENT method immediately (e.g., JS click).
 3. **Efficiency**:
+   - \`navigate\` and \`web_search\` return page content + interactive elements inline — use that output directly.
+   - For read-only pages, prefer \`convert_to_markdown(uri=...)\` over navigate (faster, no browser).
    - Go directly to target URLs.
    - Don't wait for permission to fix simple errors.
 4. **Communication**:


### PR DESCRIPTION
### Summary
This PR significantly improves web browsing performance by eliminating redundant tool calls and leveraging faster content extraction paths.

### Key Changes
1.  **Smart Navigation**: Enhanced the Playwright `navigate` tool to automatically return the page title, a text preview (~2000 chars), and the top 15 interactive elements (links, buttons, inputs) with their selectors. This saves 1-2 LLM round-trips per page load.
2.  **Enhanced Search**: The `web_search` tool now includes the top 10 clickable search result links directly in its output, allowing the agent to move to results immediately.
3.  **MarkItDown Fast-Path**: Updated the system prompt to explicitly guide the LLM towards using the `convert_to_markdown` tool (MarkItDown MCP) for read-only research tasks. This is ~10x faster than launching a browser.
4.  **Self-Healing Fallbacks**: Added recovery hints that suggest using `convert_to_markdown` when Playwright content-reading tools time out or fail.
5.  **Dynamic Protocols**: Updated the RESEARCH and GENERAL protocol guidelines to prioritize these faster execution paths.