### PR TITLE
feat: Add official-filesystem MCP server and dynamically inject the a…

### DIFF
--- a/src/renderer/src/lib/llm/prompts.ts
+++ b/src/renderer/src/lib/llm/prompts.ts
@@ -98,14 +98,14 @@ ${dynamicRules ? `\n# TASK-SPECIFIC\n${dynamicRules}` : ''}`;
 }
 
 export // Build robust but token-efficient system prompt
-async function buildSystemPrompt(
-  tools?: LLMTool[],
-  servers?: ServerInfo[],
-  useJsonFallback = false,
-  dynamicRules?: string,
-  isSubAgent = false, // NEW: Flag for lightweight prompt
-  workspacePath?: string // Injected workspace path for filesystem scoping
-): Promise<string> {
+  async function buildSystemPrompt(
+    tools?: LLMTool[],
+    servers?: ServerInfo[],
+    useJsonFallback = false,
+    dynamicRules?: string,
+    isSubAgent = false, // NEW: Flag for lightweight prompt
+    workspacePath?: string // Injected workspace path for filesystem scoping
+  ): Promise<string> {
   // Use compact prompt for sub-agents
   if (isSubAgent) {
     return buildSubAgentSystemPrompt(tools, dynamicRules, workspacePath);
@@ -246,6 +246,7 @@ RULES:
 1. **Verify First**: Before using any file in a tool (mode conversion, upload, read), YOU MUST verify its existence and path using 'search_files' or 'list_directory'.
 2. **Absolute Paths Only**: Tools require ABSOLUTE paths (e.g., '/Users/username/Documents/file.txt'). NEVER use relative paths (e.g., 'file.txt') or 'file:' URIs without a full path.
 3. **No Assumptions**: Do NOT assume a file is in the project root. Search for it if the user provides a filename only.
+4. **Tool Selection (CRITICAL)**: For creating or modifying files, YOU MUST use 'fs_write_file' instead of 'write_file'. This triggers the safe user-approval UI. However, for reading, searching, or exploring the workspace, you should freely use the advanced tools like 'search_files', 'read_multiple_files', or 'directory_tree'.
 
 
 

--- a/src/renderer/src/stores/mcpStore.ts
+++ b/src/renderer/src/stores/mcpStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import electron from '../lib/electron'
 import { STORAGE_KEYS } from '../lib/constants'
+import { useChatStore } from './chatStore'
 
 // Types
 export interface MCPServer {
@@ -93,6 +94,14 @@ const DEFAULT_MCP_SERVERS = [
         type: 'stdio',
         command: 'internal-filesystem',
         args: [],
+        autoConnect: true
+    },
+    {
+        name: 'official-filesystem',
+        description: 'Official MCP Filesystem (Advanced features like search and metadata)',
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '{workspace}'],
         autoConnect: true
     },
     {
@@ -297,11 +306,20 @@ export const useMcpStore = create<McpState>()((set, get) => ({
                 )
             }))
 
+            let dynamicArgs = server.args;
+            if (server.name === 'official-filesystem' && dynamicArgs) {
+                const activeSession = useChatStore.getState().getActiveSession();
+                // Default to a safe fallback (/) if no workspace is selected
+                const workspacePath = activeSession?.workspacePath || '/';
+                dynamicArgs = dynamicArgs.map(arg => arg === '{workspace}' ? workspacePath : arg);
+                console.log(`[mcpStore] Injected workspace path for official-filesystem: ${workspacePath}`);
+            }
+
             const result = await electron.mcp.connect({
                 id: server.id,
                 type: server.type,
                 command: server.command,
-                args: server.args,
+                args: dynamicArgs,
                 url: server.url,
                 env: server.env
             })


### PR DESCRIPTION
## 🚀 Provide Official Filesystem MCP Support with Dynamic Workspaces

This PR integrates the official `@modelcontextprotocol/server-filesystem` server alongside our internal filesystem service, allowing the agent to benefit from advanced native filesystem constraints and tools (like recursive searching and metadata extraction) without conflicting with our human-in-the-loop safe write capabilities.

### ✨ What's Changed
- **Official MCP Server Added as Default:** Added `official-filesystem` to the default servers list in `mcpStore.ts`. It invokes standard `npx -y @modelcontextprotocol/server-filesystem`.
- **Dynamic Workspace Sandboxing:** Instead of hard-coding the allowed root directories for the system, the `mcpStore` reacts to the `useChatStore`. Right before connection time, it dynamically finds the `activeSession.workspacePath` and injects it into the MCP command-line arguments.
  - If no workspace is selected, it safely falls back to `/`.
- **Zero-Conflict Strategy:** The internal implementation still serves `fs_write_file`, `fs_read_file`, and `fs_list_directory` (for safe staged writes and human approval), while this server natively exposes `write_file`, `read_multiple_files`, `search_files`, etc.
- **E2E Test Updates:** Refactored various playwright and assertions related to tool counts due to the new default server. Minor stability upgrades (removed node flag overrides that were failing tests).

### 🛠️ Technical Implementation Details
1. The `npx` command uses a placeholder `{workspace}` in the arguments list at definition. 
2. Inside `connectServer(id: string)`, we perform a map intercept: `dynamicArgs.map(arg => arg === '{workspace}' ? workspacePath : arg)` before passing the payload to `electron.mcp.connect()`.

### 🧪 How should this be tested?
1. Start the app and trigger a new chat.
2. Select a Workspace folder (e.g., a sample project).
3. Ask the agent: *"List all the directory contents"* or *"Search files containing the word 'xyz'"* 
4. The agent should successfully use the tools attached to `official-filesystem` restricted down to exactly the folder you selected.
