### PR TITLE
feat: auto-submit workflow tile prompts: DONT MERGE

### DIFF
--- a/src/renderer/src/components/VoiceInput.tsx
+++ b/src/renderer/src/components/VoiceInput.tsx
@@ -195,8 +195,19 @@ export function VoiceInput({ onSubmit, disabled = false, onAbort }: VoiceInputPr
     // Listen for external population events
     useEffect(() => {
         const handlePopulate = (e: CustomEvent) => {
-            const { prompt } = e.detail
+            const { prompt, autoSubmit } = e.detail
             if (prompt) {
+                if (autoSubmit && !disabled) {
+                    // Send immediately without waiting for user input
+                    onSubmit(prompt, attachments, isHeadless)
+                    setTextInput('')
+                    setText('') 
+                    setAttachments([])
+                    resetTranscript()
+                    return
+                }
+
+                // Just populate
                 setTextInput(prompt)
                 setText(prompt) // Sync with speech hook
 
@@ -215,7 +226,7 @@ export function VoiceInput({ onSubmit, disabled = false, onAbort }: VoiceInputPr
 
         window.addEventListener('populate-chat-input', handlePopulate as EventListener)
         return () => window.removeEventListener('populate-chat-input', handlePopulate as EventListener)
-    }, [setText])
+    }, [setText, onSubmit, attachments, isHeadless, disabled, resetTranscript])
 
     return (
         <div className="bg-[#1a1d23]/80 backdrop-blur-md border border-white/10 rounded-2xl p-4 transition-all duration-300 relative">

--- a/src/renderer/src/components/WorkflowTiles.tsx
+++ b/src/renderer/src/components/WorkflowTiles.tsx
@@ -33,7 +33,7 @@ const ICON_MAP: Record<string, React.ReactNode> = {
 
 export function WorkflowTiles() {
     const handleTileClick = (prompt: string) => {
-        const event = new CustomEvent('populate-chat-input', { detail: { prompt } })
+        const event = new CustomEvent('populate-chat-input', { detail: { prompt, autoSubmit: true } })
         window.dispatchEvent(event)
     }
 


### PR DESCRIPTION
Fixes friction where clicking a workflow tile only populated the text input but required the user to manually click Send. Now it automatically dispatches the action.