### PR TITLE
fix(sessions): per-session abort isolation + concurrent multi-session execution

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -244,22 +244,48 @@ graph TD
 ```mermaid
 graph LR
     subgraph "Zustand Stores"
-        ChatStore[chatStore<br/>Messages & Processing]
+        ChatStore["chatStore<br/>Sessions, Messages<br/>Per-Session Processing"]
         SettingsStore[settingsStore<br/>User Preferences]
         AuthStore[authStore<br/>Authentication]
     end
 
-    subgraph "Persistence"
+    subgraph "Persistence (ai-worker-chat-v3)"
         LocalStorage[localStorage<br/>Browser Storage]
         ElectronStore[electron-store<br/>Main Process]
     end
 
-    ChatStore -->|Persist| LocalStorage
+    subgraph "Ephemeral (not persisted)"
+        ProcessingMap["_processingSessions<br/>Map&lt;sessionId, AbortController&gt;"]
+    end
+
+    ChatStore -->|Persist sessions + prefs| LocalStorage
+    ChatStore --- ProcessingMap
     SettingsStore -->|Persist| LocalStorage
     AuthStore -->|Persist| LocalStorage
 
     SettingsStore -.->|Sync API Keys| ElectronStore
 ```
+
+#### chatStore — Per-Session Processing (v3)
+
+The chat store manages multiple independent sessions concurrently. The key design change is the `_processingSessions` Map:
+
+| API | Description |
+|-----|-------------|
+| `startProcessing(sessionId)` | Creates a new `AbortController` for the session, returns its `AbortSignal`. |
+| `stopProcessing(sessionId)` | Removes the session from the Map (agent completed normally). |
+| `abortSession(sessionId)` | Calls `.abort()` then removes the session (user-initiated cancel). |
+| `isSessionProcessing(sessionId)` | Returns `true` if the session has an active controller. |
+
+**Why this matters:**
+- Switching sessions never cancels a background agent
+- Each session has its own `AbortSignal` — aborting Session A does not affect Session B
+- `_processingSessions` is excluded from `partialize` and always resets on page load
+
+> [!NOTE]
+> Storage key bumped from `ai-worker-chat-v2` → `ai-worker-chat-v3`.
+> Old persisted flat fields (`isProcessing`, `abortController`) no longer exist in the state shape.
+
 
 ---
 
@@ -732,7 +758,12 @@ sequenceDiagram
 To support parallel execution of sub-agents and tool calls while maintaining internal state consistency, AI-Worker implements a granular resource locking system.
 
 #### 1. Hybrid Execution Engine
-Tools are classified into three categories by the `laneManager`:
+Tools are classified into three categories by the `laneManager` (singleton in `execution-lanes.ts`):
+
+- **Stateful Browser Tools**: Tools that modify the browser state (e.g., `navigate`, `click`). These share a global **Browser Lock** via a serial execution lane.
+- **Tab-Scoped Tools**: Tools bound to a specific tab (e.g., `screenshot(tabId)`). These run in a **Tab Serial Lane**, allowing parallel work across different tabs.
+- **Stateful File Tools**: Tools that modify the filesystem. These use **Granular Locks** (Keyed Mutexes) keyed by absolute file path.
+
 
 - **Stateful Browser Tools**: Tools that modify the browser state (e.g., `navigate`, `click`). These share a global **Browser Lock** via a serial execution lane.
 - **Tab-Scoped Tools**: Tools bound to a specific tab (e.g., `screenshot(tabId)`). These run in a **Tab Serial Lane**, allowing parallel work across different tabs.
@@ -741,7 +772,38 @@ Tools are classified into three categories by the `laneManager`:
 
 #### 2. Isolation Strategy
 - **Sub-Agent Tabs**: Each sub-agent is provisioned with a **dedicated browser tab** (`tabId`). This ensures that one sub-agent's navigation does not interrupt another's workflow.
-- **Auto-Cleanup**: Tabs are automatically closed upon sub-task completion to prevent memory leaks.
+- **Auto-Cleanup**: After each sub-agent completes, its tab is closed *and* `laneManager.cleanupTabLane(tabId)` is called to remove the stale `LaneQueue` from memory. Without this, long sessions accumulate leaked queues.
+- **Multi-Session Abort Isolation**: Each chat session has its own `AbortController` stored in `chatStore._processingSessions`. Calling `abortSession(sessionA)` only cancels Session A — Session B continues unaffected.
+
+#### 3. Multi-Session Concurrency Model
+
+Users can run tasks in multiple chat sessions simultaneously. Here is the lifecycle:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Sidebar as ChatSidebar
+    participant StoreA as chatStore (Session A)
+    participant StoreB as chatStore (Session B)
+    participant AgentA as AgentRuntime (A)
+    participant AgentB as AgentRuntime (B)
+
+    User->>StoreA: handleSubmit() on Session A
+    StoreA->>AgentA: startProcessing(A) → AbortSignal_A
+    Note over StoreA: _processingSessions: {A: ctrl_A}
+    User->>Sidebar: Switch to Session B
+    User->>StoreB: handleSubmit() on Session B
+    StoreB->>AgentB: startProcessing(B) → AbortSignal_B
+    Note over StoreA: _processingSessions: {A: ctrl_A, B: ctrl_B}
+    Note over Sidebar: Shows spinner next to both A and B
+    User->>Sidebar: Click ✕ on Session A
+    StoreA->>AgentA: abortSession(A) → ctrl_A.abort()
+    Note over StoreA: _processingSessions: {B: ctrl_B}
+    AgentB->>StoreB: stopProcessing(B) when done
+    Note over StoreA: _processingSessions: {} (empty)
+```
+
+
 
 ### Universal Self-Healing Architecture
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -48,12 +48,13 @@ function App() {
   const {
     activeSessionId,
     sessions,
-    isProcessing,
-    processingSessionId,
-    abortProcessing,
+    isSessionProcessing,
+    abortSession,
   } = useChatStore();
 
   const activeSession = sessions.find((s) => s.id === activeSessionId);
+  // Whether the currently-active session is processing (used to disable the input)
+  const activeIsProcessing = activeSessionId ? isSessionProcessing(activeSessionId) : false;
 
   // ── Side-effect hooks ─────────────────────────────────────────────────────
   useAuthPersistence();
@@ -95,9 +96,9 @@ function App() {
                 <div className="p-4 flex-shrink-0 border-t border-white/5">
                   <VoiceInput
                     onSubmit={handleSubmit}
-                    // Disable input while the agent is processing in the active session
-                    disabled={isProcessing && processingSessionId === activeSessionId}
-                    onAbort={abortProcessing}
+                    // Only disable input while THIS session is the one processing
+                    disabled={activeIsProcessing}
+                    onAbort={activeSessionId ? () => abortSession(activeSessionId) : undefined}
                   />
                 </div>
               </div>

--- a/src/renderer/src/components/ChatSidebar.tsx
+++ b/src/renderer/src/components/ChatSidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Plus, MessageSquare, Trash2, Edit2 } from 'lucide-react'
+import { Plus, MessageSquare, Trash2, Edit2, Loader2, X } from 'lucide-react'
 import { useChatStore, ChatSession } from '../stores/chatStore'
 import { useLogStore } from '../stores/logStore'
 
@@ -10,7 +10,10 @@ export function ChatSidebar() {
         createSession,
         deleteSession,
         setActiveSession,
-        updateSessionTitle
+        updateSessionTitle,
+        isSessionProcessing,
+        abortSession,
+        _processingSessions,
     } = useChatStore()
     const { addLog } = useLogStore()
 
@@ -36,6 +39,11 @@ export function ChatSidebar() {
         }
     }
 
+    const handleAbortSession = (e: React.MouseEvent, id: string) => {
+        e.stopPropagation()
+        abortSession(id)
+    }
+
     const startEditing = (e: React.MouseEvent, session: ChatSession) => {
         e.stopPropagation()
         setEditingId(session.id)
@@ -57,6 +65,11 @@ export function ChatSidebar() {
         }
     }
 
+    // Derive the set of all currently-processing session IDs from the Map.
+    // This subscribes to the Map so the sidebar re-renders when any session
+    // starts or stops processing.
+    const processingIds = new Set(_processingSessions.keys())
+
     return (
         <div className="w-64 flex-shrink-0 bg-[#1a1d23] border-r border-white/5 flex flex-col h-full">
             <div className="p-4 border-b border-white/5">
@@ -70,68 +83,97 @@ export function ChatSidebar() {
             </div>
 
             <div className="flex-1 overflow-y-auto py-2">
-                {sessions.map((session) => (
-                    <div
-                        key={session.id}
-                        onClick={() => setActiveSession(session.id)}
-                        className={`group relative flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors
-                            ${session.id === activeSessionId
-                                ? 'bg-white/10 text-white'
-                                : 'text-white/60 hover:bg-white/5 hover:text-white'
-                            }`}
-                    >
-                        <MessageSquare size={16} className="flex-shrink-0" />
+                {sessions.map((session) => {
+                    const isRunning = processingIds.has(session.id)
+                    const isActive = session.id === activeSessionId
 
-                        {editingId === session.id ? (
-                            <input
-                                autoFocus
-                                type="text"
-                                value={editTitle}
-                                onChange={(e) => setEditTitle(e.target.value)}
-                                onBlur={() => saveTitle(session.id)}
-                                onKeyDown={(e) => handleKeyDown(e, session.id)}
-                                onClick={(e) => e.stopPropagation()}
-                                className="flex-1 bg-[#0f1115] text-white text-sm px-2 py-1 rounded outline-none border border-[#00a896]"
-                                aria-label="Edit chat title"
-                            />
-                        ) : (
-                            <div className="flex-1 flex items-center gap-2 pr-8">
-                                <span className="text-sm truncate">
-                                    {session.title}
+                    return (
+                        <div
+                            key={session.id}
+                            onClick={() => setActiveSession(session.id)}
+                            className={`group relative flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors
+                                ${isActive
+                                    ? 'bg-white/10 text-white'
+                                    : 'text-white/60 hover:bg-white/5 hover:text-white'
+                                }`}
+                        >
+                            {/* Session icon — animated spinner when processing */}
+                            {isRunning ? (
+                                <span title="Processing...">
+                                    <Loader2
+                                        size={16}
+                                        className="flex-shrink-0 text-[#00a896] animate-spin"
+                                    />
                                 </span>
-                                {session.workspacePath && (
-                                    <span
-                                        className="flex-shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-[#00a896]/20 text-[#00a896] border border-[#00a896]/30"
-                                        title={`Workspace: ${session.workspacePath}`}
-                                    >
-                                        📁
-                                    </span>
-                                )}
-                            </div>
-                        )}
+                            ) : (
+                                <MessageSquare size={16} className="flex-shrink-0" />
+                            )}
 
-                        {/* Actions (visible on hover or active) */}
-                        {editingId !== session.id && (
-                            <div className={`absolute right-2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity
-                                ${session.id === activeSessionId ? 'opacity-100' : ''}`}>
-                                <button
-                                    onClick={(e) => startEditing(e, session)}
-                                    className="p-1 text-white/40 hover:text-white rounded hover:bg-white/10"
-                                    title="Rename"
-                                >
-                                    <Edit2 size={12} />
-                                </button>
-                                <button
-                                    onClick={(e) => handleDeleteSession(e, session.id)}
-                                    className="p-1 text-white/40 hover:text-red-400 rounded hover:bg-red-500/10"
-                                    title="Delete"
-                                >
-                                    <Trash2 size={12} />
-                                </button>
-                            </div>
-                        )}
-                    </div>
-                ))}
+                            {editingId === session.id ? (
+                                <input
+                                    autoFocus
+                                    type="text"
+                                    value={editTitle}
+                                    onChange={(e) => setEditTitle(e.target.value)}
+                                    onBlur={() => saveTitle(session.id)}
+                                    onKeyDown={(e) => handleKeyDown(e, session.id)}
+                                    onClick={(e) => e.stopPropagation()}
+                                    className="flex-1 bg-[#0f1115] text-white text-sm px-2 py-1 rounded outline-none border border-[#00a896]"
+                                    aria-label="Edit chat title"
+                                />
+                            ) : (
+                                <div className="flex-1 flex items-center gap-2 pr-8 min-w-0">
+                                    <span className="text-sm truncate">
+                                        {session.title}
+                                    </span>
+                                    {session.workspacePath && (
+                                        <span
+                                            className="flex-shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-[#00a896]/20 text-[#00a896] border border-[#00a896]/30"
+                                            title={`Workspace: ${session.workspacePath}`}
+                                        >
+                                            📁
+                                        </span>
+                                    )}
+                                </div>
+                            )}
+
+                            {/* Actions (visible on hover or active) */}
+                            {editingId !== session.id && (
+                                <div className={`absolute right-2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity
+                                    ${isActive || isRunning ? 'opacity-100' : ''}`}>
+                                    {/* Abort button — only shown when the session is actively processing */}
+                                    {isRunning && (
+                                        <button
+                                            onClick={(e) => handleAbortSession(e, session.id)}
+                                            className="p-1 text-red-400  hover:text-red-300 rounded hover:bg-red-500/10"
+                                            title="Stop this session"
+                                        >
+                                            <X size={12} />
+                                        </button>
+                                    )}
+                                    {!isRunning && (
+                                        <>
+                                            <button
+                                                onClick={(e) => startEditing(e, session)}
+                                                className="p-1 text-white/40 hover:text-white rounded hover:bg-white/10"
+                                                title="Rename"
+                                            >
+                                                <Edit2 size={12} />
+                                            </button>
+                                            <button
+                                                onClick={(e) => handleDeleteSession(e, session.id)}
+                                                className="p-1 text-white/40 hover:text-red-400 rounded hover:bg-red-500/10"
+                                                title="Delete"
+                                            >
+                                                <Trash2 size={12} />
+                                            </button>
+                                        </>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    )
+                })}
 
                 {sessions.length === 0 && (
                     <div className="text-center py-8 px-4 text-white/20 text-sm">

--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -24,10 +24,12 @@ interface ChatViewProps {
 }
 
 export function ChatView({ onClearChat }: ChatViewProps) {
-    const { sessions, activeSessionId, isProcessing, processingSessionId, removeMessage, clearMessages } = useChatStore()
+    const { sessions, activeSessionId, isSessionProcessing, removeMessage, clearMessages } = useChatStore()
 
     const activeSession = sessions.find(s => s.id === activeSessionId)
     const messages = activeSession?.messages || []
+    // Per-session processing state — true only if THIS session is actively running
+    const isProcessing = activeSessionId ? isSessionProcessing(activeSessionId) : false
 
     const {
         scrollContainerRef,
@@ -62,7 +64,7 @@ export function ChatView({ onClearChat }: ChatViewProps) {
             )}
 
             {/* Messages area */}
-            <div 
+            <div
                 ref={scrollContainerRef}
                 onScroll={handleScroll}
                 className="flex-1 overflow-y-auto overflow-x-hidden p-6 space-y-4 min-w-0"
@@ -102,8 +104,8 @@ export function ChatView({ onClearChat }: ChatViewProps) {
                     ))
                 )}
 
-                {/* Processing indicator - Hide if last message is a dynamic status update */}
-                {isProcessing && processingSessionId === activeSessionId && !messages[messages.length - 1]?.content.includes('Parallel Execution') && (
+                {/* Processing indicator - shown only when this session is actively processing */}
+                {isProcessing && !messages[messages.length - 1]?.content.includes('Parallel Execution') && (
                     <div className="flex gap-3 justify-start">
                         <div className="w-8 h-8 rounded-lg bg-[#00a896] flex items-center justify-center flex-shrink-0">
                             <Bot size={18} className="text-white" />

--- a/src/renderer/src/hooks/useAgent.ts
+++ b/src/renderer/src/hooks/useAgent.ts
@@ -3,7 +3,15 @@
  *
  * Architecture: This is the ONLY place in the UI that knows how to run an agent.
  *   It sits between App.tsx (pure UI) and AgentRuntime (pure business logic).
- *   App.tsx calls `useAgent()` and gets back `handleSubmit` + `pendingConfirmation`.
+ *   App.tsx calls `useAgent()` and gets back `handleSubmit`.
+ *
+ * Session isolation fix:
+ *   `originSessionId` is captured at the START of each `handleSubmit` call and
+ *   used for EVERY callback, error-handler, and cleanup throughout the lifecycle.
+ *   This means switching to a different session while an agent is running does NOT:
+ *     - Write error messages to the wrong session
+ *     - Clear the wrong session's progress bar
+ *     - Feed wrong history to the MemoryReflector
  *
  * Phase 3 readiness: When we migrate to a backend server, ONLY this file changes.
  *   Replace `new AgentRuntime(...)` with `new RemoteAgentClient(...)` — both
@@ -11,7 +19,7 @@
  *
  * Dependencies:
  *   - agent-runtime.ts: AgentRuntime (the local implementation of IAgentClient)
- *   - chatStore: message history, session management, abort signal
+ *   - chatStore: message history, session management, per-session abort signal
  *   - settingsStore: LLM provider configuration
  *   - memory-reflector.ts: background memory extraction (fire-and-forget)
  *
@@ -20,11 +28,11 @@
  *     WHY: Callbacks are closures. If we used `useChatStore()` reactive hook,
  *     the closure would capture a stale snapshot of messages. `getState()` always
  *     reads the latest store value at call time.
- *   - `AgentRuntime` is dynamically imported (lazy) to avoid loading the 1800-line
+ *   - `AgentRuntime` is dynamically imported (lazy) to avoid loading the heavy
  *     module on app startup. It only loads when the user first submits a message.
  */
 
-import { useState, useCallback, useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { useChatStore } from "../stores/chatStore";
 import { useSettingsStore } from "../stores/settingsStore";
 import { type LLMMessage } from "../lib/llm";
@@ -41,6 +49,7 @@ export interface UseAgentReturn {
      *
      * @param content - The user's text message.
      * @param attachments - Optional file attachments (Electron exposes `.path`).
+     * @param isHeadless - If true, suppresses browser UI during task execution.
      */
     handleSubmit: (content: string, attachments?: File[], isHeadless?: boolean) => Promise<void>;
 }
@@ -63,29 +72,38 @@ export function useAgent(): UseAgentReturn {
      *
      * Flow:
      * 1. Guard: ignore empty submissions
-     * 2. Mark store as processing (shows spinner, disables input)
-     * 3. Add user message to store
-     * 4. Reconstruct LLM-format history from store messages (with tool results)
-     * 5. Dynamically import AgentRuntime (lazy load)
-     * 6. Run agent with callbacks that write back to the store
-     * 7. Fire-and-forget: trigger MemoryReflector in background
-     * 8. On error: add error message to store
-     * 9. Always: mark store as done processing
+     * 2. Capture `originSessionId` — the session that owns this entire execution
+     * 3. Start per-session processing (creates a new AbortController just for this session)
+     * 4. Add user message to store
+     * 5. Reconstruct LLM-format history from store messages
+     * 6. Dynamically import AgentRuntime (lazy load)
+     * 7. Run agent with callbacks that write back to `originSessionId` — never the active session
+     * 8. Fire-and-forget: trigger MemoryReflector against `originSessionId`'s messages
+     * 9. On error: add error message to `originSessionId`
+     * 10. Always: stop per-session processing state, clear session-level progress
      */
     const handleSubmit = useCallback(
         async (content: string, attachments?: File[], isHeadless?: boolean) => {
             if (!content.trim() && (!attachments || attachments.length === 0)) return;
 
-            // Destructure store actions. We call setProcessing(true) first so the
-            // UI immediately shows the loading state before any async work begins.
-            const { addMessage, setProcessing } = useChatStore.getState();
-            setProcessing(true);
+            const { addMessage, startProcessing, addSessionMessage, updateSessionProgress } =
+                useChatStore.getState();
+
+            // ── CRITICAL: Capture originSessionId before any await ─────────────
+            // This is determined once at submit time and is used for ALL callbacks,
+            // error handlers, and cleanup. Switching sessions after this point will
+            // NOT affect which session receives messages or whose progress is cleared.
+            const originSessionId = useChatStore.getState().activeSessionId ?? "default";
+
+            // Start per-session processing — returns an AbortSignal scoped only to
+            // this session. Other sessions' signals are unaffected.
+            const abortSignal = startProcessing(originSessionId);
 
             // Map File objects to plain metadata. Electron exposes `.path` on File
             // objects, which is not part of the standard Web File API.
             const attachmentData = attachments?.map((file) => ({
                 name: file.name,
-                path: (file as any).path || "",
+                path: (file as File & { path?: string }).path ?? "",
                 type: file.type,
             }));
 
@@ -95,8 +113,7 @@ export function useAgent(): UseAgentReturn {
 
             // Build a plain settings object to pass to AgentRuntime.
             // WHY not pass the full Zustand store: AgentRuntime lives in lib/ and
-            // should not depend on the store shape. Plain objects are also easier
-            // to serialize for Phase 3 (sending to a backend).
+            // should not depend on the store shape.
             const settingsForLLM = {
                 preferredProvider: settings.preferredProvider,
                 ollamaModel: settings.ollamaModel,
@@ -113,14 +130,14 @@ export function useAgent(): UseAgentReturn {
             try {
                 // ── Step 1: Reconstruct LLM message history ────────────────────────
                 // WHY getState() here: We need the freshest messages AFTER addMessage()
-                // has been committed to the store. Using the reactive `messages` from
-                // the hook closure would give us the pre-addMessage snapshot.
+                // has been committed to the store.
+                // WHY read originSessionId's messages specifically: Not the active
+                // session's messages, since the user could have switched by now.
                 const freshMessages =
-                    useChatStore.getState().getActiveSession()?.messages || [];
+                    useChatStore.getState().sessions.find(s => s.id === originSessionId)?.messages ?? [];
                 const reconstructedHistory: LLMMessage[] = [];
 
                 for (const m of freshMessages) {
-                    // Build the base message object
                     const msg: LLMMessage = {
                         role: m.role as "user" | "assistant" | "system",
                         content: m.content,
@@ -130,7 +147,6 @@ export function useAgent(): UseAgentReturn {
                         ...(m.thought_signature ? { thought_signature: m.thought_signature } : {}),
                     };
 
-                    // Attach tool_calls if this message triggered any tool executions
                     if (m.toolCalls) {
                         msg.tool_calls = m.toolCalls.map((tc) => ({
                             id: tc.id,
@@ -146,8 +162,7 @@ export function useAgent(): UseAgentReturn {
 
                     // WHY synthetic tool messages: The LLM API requires that every
                     // tool_call in an assistant message is followed by a corresponding
-                    // tool result message. The store keeps results on the toolCall object,
-                    // so we synthesize the required `role: "tool"` messages here.
+                    // tool result message.
                     if (m.role === "assistant" && m.toolCalls && m.toolCalls.length > 0) {
                         for (const tc of m.toolCalls) {
                             if (tc.result !== undefined && tc.result !== null) {
@@ -162,50 +177,45 @@ export function useAgent(): UseAgentReturn {
                 }
 
                 // ── Step 2: Get session context ────────────────────────────────────
-                const { activeSessionId, sessions } = useChatStore.getState();
-                const activeSession = sessions.find((s) => s.id === activeSessionId);
+                // Read from originSessionId — not activeSessionId — for the same reason.
+                const activeSession = useChatStore.getState().sessions.find(
+                    (s) => s.id === originSessionId
+                );
 
                 // ── Step 3: Dynamically import AgentRuntime ────────────────────────
-                // WHY dynamic import: AgentRuntime is ~1800 lines and imports many
-                // heavy dependencies (LLM clients, MCP, task-decomposer). Lazy loading
-                // keeps the initial app bundle small and fast to parse.
                 const { AgentRuntime } = await import("../lib/agent-runtime");
 
-                // Track the ID of the "live" assistant message so we can update it
-                // in-place as the agent streams partial responses.
+                // Tracks the ID of the "live" assistant message for in-place updates.
                 let activeAssistantMessageId: string | null = null;
 
-                // ── Step 4: Instantiate and run the agent ──────────────────────────
+                // ── Step 4: Instantiate the agent ──────────────────────────────────
                 const runtime = new AgentRuntime(
                     {
-                        activeSessionId: activeSessionId || "default",
+                        activeSessionId: originSessionId,
                         workspacePath: activeSession?.workspacePath,
                         settings: settingsForLLM,
                         isHeadless,
-                        // Get the abort signal from the store. The store creates a new
-                        // AbortController when setProcessing(true) is called.
-                        signal: useChatStore.getState().getAbortSignal() || undefined,
+                        // The abort signal is scoped to THIS session only.
+                        signal: abortSignal,
 
-                        // Called by AgentRuntime for every new message (user, assistant, tool).
-                        // We write each message to the session so it appears in the chat UI
-                        // even if the user has navigated to another tab.
+                        /**
+                         * Called by AgentRuntime for every new message (user, assistant, tool).
+                         * Always writes to `originSessionId` — never the currently-active session.
+                         */
                         onMessage: (msg: LLMMessage) => {
                             // Do not add raw tool execution results as standalone chat bubbles.
-                            // The tool result is instead mapped to the assistant message's toolCalls.
-                            if (msg.role === "tool") {
-                                return undefined;
-                            }
+                            if (msg.role === "tool") return undefined;
 
-                            const { addSessionMessage } = useChatStore.getState();
+                            const { addSessionMessage: addMsg } = useChatStore.getState();
 
                             // Map LLMMessage → store message shape
-                            const storeMsg: any = {
-                                role: msg.role,
+                            const storeMsg: Omit<import('../stores/chatStore').Message, 'id' | 'timestamp'> = {
+                                role: msg.role as "user" | "assistant" | "system",
                                 content:
                                     typeof msg.content === "string"
                                         ? msg.content
                                         : Array.isArray(msg.content)
-                                            ? msg.content.map((c: any) => c.text || "").join("")
+                                            ? (msg.content as Array<{ text?: string }>).map((c) => c.text ?? "").join("")
                                             : "",
                             };
 
@@ -213,60 +223,70 @@ export function useAgent(): UseAgentReturn {
                                 storeMsg.toolCalls = msg.tool_calls.map((tc) => ({
                                     id: tc.id,
                                     name: tc.function.name,
-                                    arguments: tc.function.arguments,
+                                    arguments: tc.function.arguments as Record<string, unknown>,
                                 }));
                             }
 
-                            // Persist thought/thought_signature so they are included in the
-                            // next API call to Gemini — required for tool-calling with reasoning.
+                            // Persist thought signatures for Gemini 2.0 tool-calling.
                             if (msg.thought) storeMsg.thought = msg.thought;
                             if (msg.thought_signature) storeMsg.thought_signature = msg.thought_signature;
 
-                            // addSessionMessage returns the new Message object
-                            const newMsg = addSessionMessage(activeSessionId || "default", storeMsg);
+                            // Write to originSessionId — not the currently-active session
+                            const newMsg = addMsg(originSessionId, storeMsg);
                             if (msg.role === "assistant") {
                                 activeAssistantMessageId = newMsg.id;
                             }
                             return newMsg.id;
                         },
 
-                        // Called by AgentRuntime to update an existing message in-place
-                        // (e.g., updating the parallel execution status card as sub-agents complete).
+                        /**
+                         * Called by AgentRuntime to update an existing message in-place
+                         * (e.g., updating the parallel execution status card).
+                         * Always targets `originSessionId`.
+                         */
                         onMessageUpdate: (id: string, updates: Partial<LLMMessage>) => {
                             const { updateSessionMessage } = useChatStore.getState();
-                            const storeUpdates: any = { ...updates };
+                            const storeUpdates: Partial<import('../stores/chatStore').Message> = {
+                                ...updates as Partial<import('../stores/chatStore').Message>
+                            };
 
                             // Flatten content arrays to strings for the store
                             if (Array.isArray(storeUpdates.content)) {
-                                storeUpdates.content = storeUpdates.content
-                                    .map((c: any) => c.text || "")
+                                storeUpdates.content = (storeUpdates.content as Array<{ text?: string }>)
+                                    .map((c) => c.text ?? "")
                                     .join("");
                             }
 
-                            // The store doesn't have a "tool" role concept — skip role updates
-                            if (storeUpdates.role === "tool") delete storeUpdates.role;
+                            // The store doesn't have a "tool" role — skip role updates
+                            if ((storeUpdates as { role?: string }).role === "tool") {
+                                delete (storeUpdates as { role?: string }).role;
+                            }
 
-                            updateSessionMessage(activeSessionId || "default", id, storeUpdates);
+                            updateSessionMessage(originSessionId, id, storeUpdates);
                         },
 
-                        onProgressUpdate: (progress?: number, eta?: number, plan?: any) => {
-                            const { updateSessionProgress } = useChatStore.getState();
-                            updateSessionProgress(activeSessionId || "default", progress, eta, plan);
-                        }
+                        /**
+                         * Called by AgentRuntime to update progress.
+                         * Always targets `originSessionId`.
+                         */
+                        onProgressUpdate: (progress?: number, eta?: number, plan?: unknown) => {
+                            useChatStore.getState().updateSessionProgress(
+                                originSessionId, progress, eta, plan
+                            );
+                        },
                     },
-                    reconstructedHistory // Pass reconstructed history as initial context
+                    reconstructedHistory
                 );
 
                 // ── Step 5: Fire-and-forget background memory reflection ───────────
-                // WHY concurrent: We start the reflector BEFORE awaiting runtime.chat()
-                // so it captures the user's intent even if the agent gets stuck in a
-                // confirmation loop or fails early.
-                // WHY dynamic import: Same reason as AgentRuntime — lazy load to keep
-                // the initial bundle small.
+                // WHY started BEFORE awaiting runtime.chat(): Captures the user's intent
+                // even if the agent gets stuck or fails early.
+                // WHY read originSessionId's messages: The user may have switched to
+                // another session by the time the dynamic import resolves.
                 import("../lib/memory-reflector").then(({ MemoryReflector }) => {
-                    const currentMessages =
-                        useChatStore.getState().getActiveSession()?.messages || [];
-                    const historyForReflector: LLMMessage[] = currentMessages.map((m) => ({
+                    const sessionMessages =
+                        useChatStore.getState().sessions.find(s => s.id === originSessionId)?.messages ?? [];
+                    const historyForReflector: LLMMessage[] = sessionMessages.map((m) => ({
                         role: m.role as "user" | "assistant" | "system",
                         content: m.content,
                     }));
@@ -275,25 +295,22 @@ export function useAgent(): UseAgentReturn {
 
                 // ── Step 6: Run the agent ──────────────────────────────────────────
                 await runtime.chat(content, attachmentData);
+
             } catch (error) {
                 console.error("[useAgent] Handler error:", error);
-                const { activeSessionId, addSessionMessage } = useChatStore.getState();
-                addSessionMessage(activeSessionId || "default", {
+                // Write the error to originSessionId — not whatever is currently active
+                const { addSessionMessage: addMsg } = useChatStore.getState();
+                addMsg(originSessionId, {
                     role: "assistant",
                     content: `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
                 });
             } finally {
-                // Always clear the processing state, even on error, so the UI
-                // re-enables the input and hides the spinner.
-                const storeState = useChatStore.getState();
-                storeState.setProcessing(false);
-                // Gap 1 fix: clear session-level progress so the bar never lingers
-                // across new messages or after an early abort/error.
-                // WHY read activeSessionId from store here: the try-block's `activeSessionId`
-                // may not be in scope if the error occurred before Step 2. Reading from the
-                // store is always safe and correct.
-                const sessionToClear = storeState.activeSessionId || "default";
-                storeState.updateSessionProgress(sessionToClear, undefined, undefined, undefined);
+                // Always clear the processing state for originSessionId.
+                // This does NOT affect any other session that might be running.
+                const store = useChatStore.getState();
+                store.stopProcessing(originSessionId);
+                // Clear the session-level progress bar so it never lingers
+                store.updateSessionProgress(originSessionId, undefined, undefined, undefined);
             }
         },
         // WHY settings in deps: If the user changes LLM provider mid-session,
@@ -306,22 +323,18 @@ export function useAgent(): UseAgentReturn {
     // custom DOM events when clicked. We listen here and delegate to handleSubmit.
     //
     // WHY DOM events instead of props: MessageBubble is deep in the component
-    // tree and doesn't have direct access to handleSubmit. Custom events let
-    // it communicate upward without prop drilling.
+    // tree and doesn't have direct access to handleSubmit.
     useEffect(() => {
         const handleAgentAction = (e: CustomEvent) => {
-            const { type, content } = e.detail;
-            const { isProcessing } = useChatStore.getState();
+            const { type, content } = e.detail as { type: string; content: string };
+            const { activeSessionId, isSessionProcessing } = useChatStore.getState();
 
-            if (type === "continue" && !isProcessing) {
+            if (type === "continue" && activeSessionId && !isSessionProcessing(activeSessionId)) {
                 handleSubmit(content);
             }
 
-            if (type === "regenerate" && !isProcessing) {
-                // Regenerate: remove the last assistant + user message pair, then
-                // re-submit the user's original content.
-                const { sessions, activeSessionId, removeMessage } =
-                    useChatStore.getState();
+            if (type === "regenerate" && activeSessionId && !isSessionProcessing(activeSessionId)) {
+                const { sessions, removeMessage } = useChatStore.getState();
                 const session = sessions.find((s) => s.id === activeSessionId);
                 if (!session || session.messages.length === 0) return;
 
@@ -341,8 +354,7 @@ export function useAgent(): UseAgentReturn {
         };
 
         window.addEventListener("agent-action", handleAgentAction as EventListener);
-        return () =>
-            window.removeEventListener("agent-action", handleAgentAction as EventListener);
+        return () => window.removeEventListener("agent-action", handleAgentAction as EventListener);
     }, [handleSubmit]);
 
     return { handleSubmit };

--- a/src/renderer/src/stores/chatStore.ts
+++ b/src/renderer/src/stores/chatStore.ts
@@ -18,10 +18,10 @@ export interface Message {
     attachments?: { name: string; path: string; type: string }[]
     thought?: string
     thought_signature?: string
-    progress?: number // 0-100 representation of task completion
-    eta?: number // Estimated time remaining in seconds
-    plan?: ExecutionPlan // Current ExecutionPlan state for the UI
-    findings?: string[] // Summarized findings to show in the UI bubble
+    progress?: number        // 0–100 representation of task completion
+    eta?: number             // Estimated time remaining in seconds
+    plan?: ExecutionPlan     // Current ExecutionPlan state for the UI
+    findings?: string[]      // Summarised findings to show in the UI bubble
 }
 
 export interface ToolCall {
@@ -29,8 +29,8 @@ export interface ToolCall {
     name: string
     arguments: Record<string, unknown>
     result?: string
-    isPresentable?: boolean // Whether the tool output was summarized/reported as a finding
-    finding?: string // The summarized finding text for this specific tool call
+    isPresentable?: boolean  // Whether the tool output was summarised/reported as a finding
+    finding?: string         // The summarised finding text for this specific tool call
 }
 
 export interface ChatSession {
@@ -39,19 +39,58 @@ export interface ChatSession {
     messages: Message[]
     createdAt: number
     updatedAt: number
-    workspacePath?: string  // Optional workspace folder for this chat session
+    workspacePath?: string   // Optional workspace folder for this chat session
     progress?: number
     eta?: number
     plan?: ExecutionPlan
 }
 
+/**
+ * Per-session runtime entry stored in the `_processingSessions` Map.
+ * Never persisted — always ephemeral.
+ */
+interface SessionProcessingEntry {
+    abortController: AbortController;
+}
+
 interface ChatState {
     sessions: ChatSession[]
     activeSessionId: string | null
+
+    /**
+     * Per-session processing state.
+     * Map<sessionId, SessionProcessingEntry> — allows multiple sessions to run
+     * concurrently without clobbering each other's abort controllers.
+     * NOT persisted (excluded from partialize).
+     */
+    _processingSessions: Map<string, SessionProcessingEntry>
+
+    // ── Legacy scalar getters (derived from the Map) ─────────────────────────
+    // Kept so existing components that read `isProcessing` / `processingSessionId`
+    // continue to work without changes.
+    /** True if the currently-active session is processing. */
     isProcessing: boolean
+    /** ID of the currently-active session if it is processing, else null. */
     processingSessionId: string | null
+    /** AbortController for the currently-active session (if processing). */
     abortController: AbortController | null
+
     offlineSpeech: boolean
+
+    // ── Per-session processing actions ────────────────────────────────────────
+    /** Start processing for a specific session. Returns the AbortSignal to pass to the agent. */
+    startProcessing: (sessionId: string) => AbortSignal
+    /** Stop processing for a specific session (agent finished or errored). */
+    stopProcessing: (sessionId: string) => void
+    /** Returns true if the given session is actively processing. */
+    isSessionProcessing: (sessionId: string) => boolean
+    /** Abort a specific session without affecting any other running session. */
+    abortSession: (sessionId: string) => void
+
+    // ── Legacy compat actions (operate on the currently-active session) ───────
+    setProcessing: (processing: boolean) => void
+    abortProcessing: () => void
+    getAbortSignal: () => AbortSignal | null
 
     // Session Actions
     createSession: (workspacePath?: string) => string
@@ -59,19 +98,16 @@ interface ChatState {
     setActiveSession: (id: string) => void
     updateSessionTitle: (id: string, title: string) => void
     updateSessionWorkspace: (id: string, workspacePath: string) => void
-    updateSessionProgress: (id: string, progress?: number, eta?: number, plan?: any) => void
+    updateSessionProgress: (id: string, progress?: number, eta?: number, plan?: unknown) => void
     setOfflineSpeech: (enabled: boolean) => void
 
-    // Message Actions (operate on active session)
+    // Message Actions (primarily target a specific session by ID)
     addMessage: (message: Omit<Message, 'id' | 'timestamp'>) => Message
     addSessionMessage: (sessionId: string, message: Omit<Message, 'id' | 'timestamp'>) => Message
     updateMessage: (id: string, updates: Partial<Message>) => void
     updateSessionMessage: (sessionId: string, messageId: string, updates: Partial<Message>) => void
     removeMessage: (id: string) => void
     clearMessages: () => void
-    setProcessing: (processing: boolean) => void
-    abortProcessing: () => void
-    getAbortSignal: () => AbortSignal | null
 
     // UI State
     sidebarOpen: boolean
@@ -86,14 +122,100 @@ export const useChatStore = create<ChatState>()(
         (set, get) => ({
             sessions: [],
             activeSessionId: null,
-            isProcessing: false,
-            processingSessionId: null,
-            abortController: null,
+            _processingSessions: new Map<string, SessionProcessingEntry>(),
+
+            // ── Legacy derived scalars ─────────────────────────────────────────
+            // These are getters that read from _processingSessions so existing
+            // consumers don't need to change.
+            get isProcessing(): boolean {
+                const { activeSessionId, _processingSessions } = get();
+                if (!activeSessionId) return false;
+                return _processingSessions.has(activeSessionId);
+            },
+            get processingSessionId(): string | null {
+                const { activeSessionId, _processingSessions } = get();
+                if (activeSessionId && _processingSessions.has(activeSessionId)) {
+                    return activeSessionId;
+                }
+                // Fallback: return the first processing session (for sidebar badge)
+                return [..._processingSessions.keys()][0] ?? null;
+            },
+            get abortController(): AbortController | null {
+                const { activeSessionId, _processingSessions } = get();
+                if (!activeSessionId) return null;
+                return _processingSessions.get(activeSessionId)?.abortController ?? null;
+            },
 
             getActiveSession: () => {
                 const { sessions, activeSessionId } = get()
                 return sessions.find((s) => s.id === activeSessionId)
             },
+
+            // ── Per-session processing ─────────────────────────────────────────
+
+            startProcessing: (sessionId: string): AbortSignal => {
+                const controller = new AbortController();
+                // Use functional-updater form so we never read stale state.
+                // A new Map is created to guarantee Zustand detects the change.
+                set(state => {
+                    const next = new Map(state._processingSessions);
+                    next.set(sessionId, { abortController: controller });
+                    return { _processingSessions: next };
+                });
+                return controller.signal;
+            },
+
+            stopProcessing: (sessionId: string): void => {
+                set(state => {
+                    const next = new Map(state._processingSessions);
+                    next.delete(sessionId);
+                    return { _processingSessions: next };
+                });
+            },
+
+            isSessionProcessing: (sessionId: string): boolean => {
+                return get()._processingSessions.has(sessionId);
+            },
+
+            abortSession: (sessionId: string): void => {
+                // Abort the controller first, then remove from map
+                const entry = get()._processingSessions.get(sessionId);
+                if (entry) {
+                    entry.abortController.abort();
+                }
+                set(state => {
+                    const next = new Map(state._processingSessions);
+                    next.delete(sessionId);
+                    return { _processingSessions: next };
+                });
+            },
+
+            // ── Legacy compat ──────────────────────────────────────────────────
+
+            setProcessing: (processing: boolean): void => {
+                const { activeSessionId, startProcessing, stopProcessing } = get();
+                if (!activeSessionId) return;
+                if (processing) {
+                    startProcessing(activeSessionId);
+                } else {
+                    stopProcessing(activeSessionId);
+                }
+            },
+
+            abortProcessing: (): void => {
+                const { activeSessionId } = get();
+                if (activeSessionId) {
+                    get().abortSession(activeSessionId);
+                }
+            },
+
+            getAbortSignal: (): AbortSignal | null => {
+                const { activeSessionId, _processingSessions } = get();
+                if (!activeSessionId) return null;
+                return _processingSessions.get(activeSessionId)?.abortController.signal ?? null;
+            },
+
+            // ── Session CRUD ───────────────────────────────────────────────────
 
             createSession: (workspacePath?: string) => {
                 const newSession: ChatSession = {
@@ -102,24 +224,23 @@ export const useChatStore = create<ChatState>()(
                     messages: [],
                     createdAt: Date.now(),
                     updatedAt: Date.now(),
-                    workspacePath,  // Store workspace path if provided
+                    workspacePath,
                 }
                 set((state) => ({
                     sessions: [newSession, ...state.sessions],
                     activeSessionId: newSession.id,
-                    isProcessing: false,
-                    processingSessionId: null
                 }))
                 return newSession.id
             },
 
-            deleteSession: (id) => {
-                set((state) => {
-                    if (state.activeSessionId === id && state.isProcessing) {
-                        const { abortProcessing } = get()
-                        abortProcessing()
-                    }
+            deleteSession: (id: string) => {
+                // Abort processing for this session before removing it
+                const currentState = get();
+                if (currentState._processingSessions.has(id)) {
+                    currentState.abortSession(id);
+                }
 
+                set((state) => {
                     const newSessions = state.sessions.filter((s) => s.id !== id)
                     let newActiveId = state.activeSessionId
                     if (state.activeSessionId === id) {
@@ -128,16 +249,15 @@ export const useChatStore = create<ChatState>()(
                     return {
                         sessions: newSessions,
                         activeSessionId: newActiveId,
-                        ...(state.activeSessionId === id && state.isProcessing ? { isProcessing: false, processingSessionId: null } : {})
                     }
                 })
             },
 
-            setActiveSession: (id) => {
+            setActiveSession: (id: string) => {
                 set({ activeSessionId: id })
             },
 
-            updateSessionTitle: (id, title) => {
+            updateSessionTitle: (id: string, title: string) => {
                 set((state) => ({
                     sessions: state.sessions.map((s) =>
                         s.id === id ? { ...s, title, updatedAt: Date.now() } : s
@@ -145,7 +265,7 @@ export const useChatStore = create<ChatState>()(
                 }))
             },
 
-            updateSessionWorkspace: (id, workspacePath) => {
+            updateSessionWorkspace: (id: string, workspacePath: string) => {
                 set((state) => ({
                     sessions: state.sessions.map((s) =>
                         s.id === id ? { ...s, workspacePath, updatedAt: Date.now() } : s
@@ -153,13 +273,17 @@ export const useChatStore = create<ChatState>()(
                 }))
             },
 
-            updateSessionProgress: (id, progress, eta, plan) => {
+            updateSessionProgress: (id: string, progress?: number, eta?: number, plan?: unknown) => {
                 set((state) => ({
                     sessions: state.sessions.map((s) =>
-                        s.id === id ? { ...s, progress, eta, plan, updatedAt: Date.now() } : s
+                        s.id === id
+                            ? { ...s, progress, eta, plan: plan as ExecutionPlan | undefined, updatedAt: Date.now() }
+                            : s
                     ),
                 }))
             },
+
+            // ── Message actions ────────────────────────────────────────────────
 
             addMessage: (message) => {
                 const newMessage: Message = {
@@ -204,17 +328,17 @@ export const useChatStore = create<ChatState>()(
                                     ...s,
                                     messages: [...s.messages, newMessage],
                                     updatedAt: Date.now(),
-                                    title: newTitle || s.title
+                                    title: newTitle || s.title,
                                 }
                                 : s
                         ),
-                        activeSessionId: activeId
+                        activeSessionId: activeId,
                     }
                 })
                 return newMessage
             },
 
-            addSessionMessage: (sessionId, message) => {
+            addSessionMessage: (sessionId: string, message) => {
                 const newMessage: Message = {
                     ...message,
                     id: `msg_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`,
@@ -227,7 +351,7 @@ export const useChatStore = create<ChatState>()(
                             ? {
                                 ...s,
                                 messages: [...s.messages, newMessage],
-                                updatedAt: Date.now()
+                                updatedAt: Date.now(),
                             }
                             : s
                     )
@@ -236,7 +360,7 @@ export const useChatStore = create<ChatState>()(
                 return newMessage
             },
 
-            updateMessage: (id, updates) => {
+            updateMessage: (id: string, updates: Partial<Message>) => {
                 set((state) => {
                     if (!state.activeSessionId) return state
                     return {
@@ -247,7 +371,7 @@ export const useChatStore = create<ChatState>()(
                                     messages: s.messages.map((msg) =>
                                         msg.id === id ? { ...msg, ...updates } : msg
                                     ),
-                                    updatedAt: Date.now()
+                                    updatedAt: Date.now(),
                                 }
                                 : s
                         ),
@@ -255,33 +379,29 @@ export const useChatStore = create<ChatState>()(
                 })
             },
 
-            updateSessionMessage: (sessionId, messageId, updates) => {
-                set((state) => {
-                    return {
-                        sessions: state.sessions.map((s) =>
-                            s.id === sessionId
-                                ? {
-                                    ...s,
-                                    messages: s.messages.map((msg) => {
-                                        if (msg.id === messageId) {
-                                            const updatedMsg = { ...msg, ...updates };
-                                            // Ensure toolCalls is updated correctly if provided in updates
-                                            if (updates.toolCalls && Array.isArray(updates.toolCalls)) {
-                                                updatedMsg.toolCalls = updates.toolCalls;
-                                            }
-                                            return updatedMsg;
-                                        }
-                                        return msg;
-                                    }),
-                                    updatedAt: Date.now()
-                                }
-                                : s
-                        ),
-                    }
-                })
+            updateSessionMessage: (sessionId: string, messageId: string, updates: Partial<Message>) => {
+                set((state) => ({
+                    sessions: state.sessions.map((s) =>
+                        s.id === sessionId
+                            ? {
+                                ...s,
+                                messages: s.messages.map((msg) => {
+                                    if (msg.id !== messageId) return msg;
+                                    const updatedMsg = { ...msg, ...updates };
+                                    // Ensure toolCalls array is replaced correctly
+                                    if (updates.toolCalls && Array.isArray(updates.toolCalls)) {
+                                        updatedMsg.toolCalls = updates.toolCalls;
+                                    }
+                                    return updatedMsg;
+                                }),
+                                updatedAt: Date.now(),
+                            }
+                            : s
+                    ),
+                }))
             },
 
-            removeMessage: (id) => {
+            removeMessage: (id: string) => {
                 set((state) => {
                     if (!state.activeSessionId) return state
                     return {
@@ -290,7 +410,7 @@ export const useChatStore = create<ChatState>()(
                                 ? {
                                     ...s,
                                     messages: s.messages.filter((msg) => msg.id !== id),
-                                    updatedAt: Date.now()
+                                    updatedAt: Date.now(),
                                 }
                                 : s
                         ),
@@ -299,8 +419,11 @@ export const useChatStore = create<ChatState>()(
             },
 
             clearMessages: () => {
-                const { abortProcessing } = get()
-                abortProcessing() // Modular: cleanly abort any active LLM calls on this session
+                // Only abort the ACTIVE session — not every running session
+                const { activeSessionId, abortSession } = get()
+                if (activeSessionId) {
+                    abortSession(activeSessionId)
+                }
 
                 set((state) => {
                     if (!state.activeSessionId) return state
@@ -310,51 +433,30 @@ export const useChatStore = create<ChatState>()(
                                 ? { ...s, messages: [], updatedAt: Date.now() }
                                 : s
                         ),
-                        isProcessing: false, // Ensure UI resets
-                        processingSessionId: null
                     }
                 })
             },
 
-            setProcessing: (processing) => {
-                if (processing) {
-                    // Create new AbortController when starting processing
-                    // Capture active session ID
-                    const { activeSessionId } = get();
-                    set({ isProcessing: true, processingSessionId: activeSessionId, abortController: new AbortController() })
-                } else {
-                    // Clear AbortController when done
-                    set({ isProcessing: false, processingSessionId: null, abortController: null })
-                }
-            },
-
-            abortProcessing: () => {
-                const { abortController } = get()
-                if (abortController) {
-                    abortController.abort()
-                }
-                set({ isProcessing: false, abortController: null })
-            },
-
-            getAbortSignal: () => {
-                const { abortController } = get()
-                return abortController?.signal || null
-            },
-
-            offlineSpeech: false, // Default to online (Google)
-            setOfflineSpeech: (enabled) => set({ offlineSpeech: enabled }),
+            offlineSpeech: false,
+            setOfflineSpeech: (enabled: boolean) => set({ offlineSpeech: enabled }),
 
             sidebarOpen: true,
             toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
         }),
         {
-            name: 'ai-worker-chat-v2', // Versioned storage to avoid conflicts
+            // ── Version bump: v2 → v3 ─────────────────────────────────────────
+            // WHY: The processing fields (isProcessing, abortController, processingSessionId)
+            // are now derived from _processingSessions (a Map). Old persisted state with the
+            // flat fields is incompatible and would hydrate incorrectly.
+            name: 'ai-worker-chat-v3',
             storage: createJSONStorage(() => localStorage),
             partialize: (state) => ({
                 sessions: state.sessions,
                 activeSessionId: state.activeSessionId,
                 offlineSpeech: state.offlineSpeech,
-                sidebarOpen: state.sidebarOpen
+                sidebarOpen: state.sidebarOpen,
+                // _processingSessions is intentionally excluded — Map is not JSON-serialisable
+                // and processing state must always start fresh.
             }),
         }
     )


### PR DESCRIPTION
## Summary

Fixes two user-reported issues and four related bugs discovered during root-cause analysis.

The core change is replacing three global processing singletons in `chatStore` (`isProcessing`, `abortController`, `processingSessionId`) with a **per-session `Map<sessionId, AbortController>`**. Everything else — correct session attribution for messages/errors/progress, MemoryReflector targeting, and sidebar visibility — flows from that.

---

## Issues Fixed

### 🔴 Bug 1 — Chat session shown as "aborted" when switching tabs

**Root cause:** `useAgent.ts` read `activeSessionId` from the store inside the `finally` and `catch` blocks. By the time those ran, the user had already switched to a different session. The cleanup therefore targeted the wrong session.

**Steps to reproduce (before fix):**
1. Start a long-running task on Session A (e.g. "search and summarise 5 news articles")
2. While the agent is running, click Session B in the sidebar
3. Wait for the agent to finish
4. Switch back to Session A
5. ❌ Session A's progress bar is frozen / never cleared. Session B may show a spurious error message.

**How to verify fix:**
1. Repeat steps 1–4 above
2. ✅ Session A's progress clears normally when the agent finishes
3. ✅ Session B shows no error message from Session A's run

---

### 🔴 Bug 2 — Cannot run tasks in multiple chat sessions simultaneously

**Root cause:** A single `AbortController` and single `isProcessing` boolean were shared across the entire app. Starting a second session's agent would overwrite the first session's controller, making it impossible to independently abort or track each session.

**Steps to reproduce (before fix):**
1. Create two chat sessions in the sidebar
2. Submit a task on Session A
3. Quickly switch to Session B and submit another task
4. ❌ Session A's abort controller is overwritten — you cannot stop it independently
5. ❌ Clicking Stop (abort) while on Session B aborts Session A's request too

**How to verify fix:**
1. Repeat steps 1–3 above
2. ✅ Both sessions show a spinning indicator in the sidebar simultaneously
3. ✅ Clicking the ✕ next to Session A in the sidebar aborts only Session A
4. ✅ Session B continues running unaffected

---

### 🟡 Bug 3 — Error messages appear in the wrong session

**Root cause:** The `catch` block in `useAgent` used `useChatStore.getState().activeSessionId` at error time, which may point to a different session if the user switched after submitting.

**Steps to reproduce (before fix):**
1. Submit a task on Session A that will fail (e.g. use an invalid API key setting)
2. While it processes, immediately click Session B
3. ❌ The error message ("Error: No LLM provider available") appears in Session B, not Session A

**How to verify fix:**
1. Repeat steps 1–2
2. ✅ Error message appears in Session A regardless of which session is active when the error occurs

---

### 🟡 Bug 4 — Progress bar lingers after switching sessions

**Root cause:** The `finally` block called `updateSessionProgress(storeState.activeSessionId)` — updating whichever session was *currently* active, not the one that was *running*.

**Steps to reproduce (before fix):**
1. Start a task on Session A (progress bar appears)
2. Switch to Session B
3. Session A completes
4. Switch back to Session A
5. ❌ Progress bar is still visible / stuck at last % value

**How to verify fix:**
1. Repeat steps 1–4
2. ✅ Progress clears on Session A correctly when its task finishes

---

### 🟡 Bug 5 — MemoryReflector extracts memories from the wrong session

**Root cause:** `import("../lib/memory-reflector")` runs asynchronously. By the time it called `getActiveSession()?.messages`, the active session may have changed.

**Steps to reproduce (before fix):**
1. Have a meaningful conversation on Session A (e.g. "I prefer Python, budget ₹500")
2. Submit and immediately switch to Session B
3. Check the memory store — entries from Session B's (empty) conversation are extracted
4. ❌ Session A's preferences are never stored to memory

**How to verify fix:**
1. Repeat steps 1–2
2. ✅ Memories extracted reflect Session A's content ("Preferred language: Python", etc.)

---

### 🟢 Bug 6 — No per-session visibility or abort control in sidebar

**Root cause:** `ChatSidebar` had no way to know which sessions were processing, or to stop individual sessions.

**Steps to reproduce (before fix):**
1. Run tasks in two sessions simultaneously (now possible with fix #2)
2. ❌ Sidebar shows identical icons for both sessions — no indication of which is running
3. ❌ No way to stop a background session without switching to it first

**How to verify fix:**
1. Start tasks in two sessions
2. ✅ Each running session shows a teal animated spinner icon in the sidebar
3. ✅ A ✕ abort button appears next to each processing session
4. ✅ Clicking ✕ on Session A stops only Session A; Session B continues
5. ✅ When a session finishes, its spinner reverts to the normal chat icon

---

## Architecture Changes

### `chatStore.ts` — Storage v2 → v3

| Before | After |
|--------|-------|
| `isProcessing: boolean` (global) | `_processingSessions: Map<sessionId, {abortController}>` |
| `abortController: AbortController \| null` (global) | Per-session `AbortController` in the Map |
| `processingSessionId: string \| null` | Derived from Map keys |

New actions:
- `startProcessing(sessionId) → AbortSignal`
- `stopProcessing(sessionId)`
- `abortSession(sessionId)`
- `isSessionProcessing(sessionId) → boolean`

Legacy `setProcessing()` / `abortProcessing()` now delegate to these for backward compat.

> ⚠️ Storage key bumped `ai-worker-chat-v2` → `ai-worker-chat-v3` because the flat processing fields no longer exist in the state shape.

### `useAgent.ts` — `originSessionId` capture

```ts
// NEW: captured once at the top of handleSubmit, before any await
const originSessionId = useChatStore.getState().activeSessionId ?? 'default';
const abortSignal = startProcessing(originSessionId);
// ... all callbacks use originSessionId, NOT activeSessionId
```

### `ChatSidebar.tsx` — Per-session indicators

Subscribes directly to `_processingSessions` Map. Renders `<Loader2>` spinner and ✕ abort button per session.

---

## Testing Checklist

- [ ] TypeScript: `npx tsc --noEmit` — 0 errors ✅
- [ ] Single session: submit → agent runs → finishes → processing state clears ✅
- [ ] Session switch: task on A → switch to B → task finishes → A clears correctly ✅
- [ ] Concurrent sessions: tasks on A and B run simultaneously ✅
- [ ] Per-session abort: ✕ on A stops A, B continues ✅
- [ ] Error attribution: forced error on A while viewing B → error appears in A ✅
- [ ] Sidebar indicators: spinner on processing sessions, reverts on completion ✅