### PR TITLE
Refactor: Self-Describing Playwright Tools

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -866,6 +866,9 @@ sequenceDiagram
 
 #### 2. Runtime Preconditions (Pre-Validation & Auto-Fallback)
 The `PlaywrightService` implements proactive validation for multi-step tools (`browser_action_sequence` and `fill_form`) to prevent hallucinated selectors from causing partial executions or long timeouts.
+
+### Browser Lifecycle (Idle Timeout)
+To prevent the Chromium process from holding hundreds of megabytes of RAM while the application is idle, `BrowserManager.ts` implements an automatic idle timeout. If no browser tools are requested for 5 minutes, the Chromium process is gracefully terminated. It will seamlessly relaunch (JIT) the next time the agent requires browser capabilities.
 - **Auto-Observation Guard**: Automatically checks `page.$(selector)` implicitly before executing any step.
 - **Fail-Fast Sequence Validation**: Validates all selectors in a sequence *before* running. If a selector is missing, the sequence aborts instantly (~50ms) instead of waiting for a 30s timeout, saving tokens and time. 
 - **Smart Auto-Fallback**: If a `click` selector is invalid but acts like or is accompanied by valid `text`, the runtime automatically upgrades the action to `click_text` on the fly.

--- a/src/main/services/PlaywrightService.ts
+++ b/src/main/services/PlaywrightService.ts
@@ -19,7 +19,7 @@
  * Consumed by: AgentRuntime, AppMain (IPC handlers)
  */
 
-import { ToolSchema, BROWSER_TURBO_SCHEMAS } from '../../shared/browser-tool-schemas';
+import { ToolSchema } from '../../shared/browser-tool-schemas';
 import { Page } from 'playwright-core';
 import { BrowserManager } from './playwright/BrowserManager';
 import { PlaywrightTool, ToolResult, PlaywrightContext } from './playwright/PlaywrightTool';
@@ -62,6 +62,10 @@ export class PlaywrightService {
         const toolList = getPlaywrightTools();
         for (const tool of toolList) {
             this.tools.set(tool.name, tool);
+            // Register tool-declared aliases (e.g., browser_navigate → navigate)
+            for (const alias of tool.aliases) {
+                this.tools.set(alias, tool);
+            }
         }
     }
 
@@ -81,6 +85,11 @@ export class PlaywrightService {
             const tool = this.tools.get(name);
             if (!tool) {
                 return { result: null, error: `Tool ${name} not found` };
+            }
+
+            // Ensure background_scrape always uses our managed headless context
+            if (name === 'background_scrape') {
+                args = { ...args, _headless: true };
             }
 
             const page = await this.browserManager.getPage(args);
@@ -122,360 +131,24 @@ export class PlaywrightService {
      * @returns An object containing an array of tool schemas.
      */
     listTools(): { tools: ToolSchema[] } {
-        return {
-            tools: [
-                {
-                    name: 'navigate',
-                    description: 'NAVIGATION: Go to a URL. Use this FIRST to open any website. Example: navigate to "https://google.com" before searching.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            url: { type: 'string', description: 'Full URL including https://' }
-                        },
-                        required: ['url']
-                    }
-                },
-                {
-                    name: 'screenshot',
-                    description: 'VISION: Capture the current page as an image. Use when you need to see the page visually or save visual evidence. For perceiving page state, prefer get_state instead.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            fullPage: { type: 'boolean', description: 'true=capture entire scrollable page, false=visible viewport only' }
-                        }
-                    }
-                },
-                {
-                    name: 'click',
-                    description: 'INTERACTION: Click an element using CSS selector. Use when you know the exact selector (e.g., "#submit-btn", ".login-button"). If you only know the text, use click_text instead.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            selector: { type: 'string', description: 'CSS selector like #id, .class, or tag[attr="value"]' }
-                        },
-                        required: ['selector']
-                    }
-                },
-                {
-                    name: 'fill',
-                    description: 'INPUT: Instantly fill a text input, textarea, or contenteditable field. Use for forms, search boxes, login fields. Replaces existing content. For character-by-character typing, use "type" instead.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            selector: { type: 'string', description: 'CSS selector of the input field' },
-                            value: { type: 'string', description: 'Text to enter' }
-                        },
-                        required: ['selector', 'value']
-                    }
-                },
-                {
-                    name: 'hover',
-                    description: 'INTERACTION: Move mouse over an element without clicking. Use to reveal dropdown menus, tooltips, or trigger hover states before clicking sub-items.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            selector: { type: 'string', description: 'CSS selector of element to hover' }
-                        },
-                        required: ['selector']
-                    }
-                },
-                {
-                    name: 'press',
-                    description: 'KEYBOARD: Press a single key. Use for Enter (submit forms), Escape (close dialogs), Tab (navigate fields), ArrowDown/Up (navigate lists). Common keys: Enter, Escape, Tab, Space, Backspace, ArrowUp/Down/Left/Right.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            key: { type: 'string', description: 'Key name: Enter, Escape, Tab, Space, ArrowDown, etc.' }
-                        },
-                        required: ['key']
-                    }
-                },
-                {
-                    name: 'scroll',
-                    description: 'NAVIGATION: Scroll the page to see more content. Use "down" to load more items, "top" to return to beginning, "bottom" to reach footer/end of page.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            direction: { type: 'string', enum: ['up', 'down', 'top', 'bottom'], description: 'up/down=scroll by amount, top/bottom=jump to edge' },
-                            amount: { type: 'number', description: 'Pixels to scroll (default: 500). Only used for up/down.' }
-                        },
-                        required: ['direction']
-                    }
-                },
-                {
-                    name: 'evaluate',
-                    description: 'ADVANCED: Execute raw JavaScript code on the page. Use as a last resort when no other tool can accomplish the task. Can access DOM, modify page, or extract complex data. NOTE: document.querySelectorAll returns a NodeList, not Array. Use Array.from() before .map(), .filter(), or .slice(). if any issues occurs while executing the script, try to google the error and fix it.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            script: { type: 'string', description: 'JavaScript code to execute. Return value will be included in result.' }
-                        },
-                        required: ['script']
-                    }
-                },
-                {
-                    name: 'get_state',
-                    description: 'PERCEPTION: Understand what is on the current page. Use this AFTER navigation to see page elements. Modes: "fast"=quick text list (recommended), "full"=detailed DOM tree, "vision"=screenshot with labeled elements.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            mode: { type: 'string', enum: ['fast', 'full', 'vision'], description: 'fast=elements only (fastest, lowest tokens), full=elements+DOM tree, vision=screenshot+numbered elements' },
-                            screenshot: { type: 'boolean', description: 'Force include screenshot (auto in vision mode)' },
-                            tree: { type: 'boolean', description: 'Force include DOM tree (auto in full mode)' },
-                            highlight: { type: 'boolean', description: 'Draw numbered boxes on interactive elements in screenshot' }
-                        }
-                    }
-                },
-                {
-                    name: 'get_interactive_elements',
-                    description: 'PERCEPTION: Get a compact list of clickable elements (buttons, links, inputs) with their text and selectors. FASTEST way to understand page structure. Use this to find what to click.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            limit: { type: 'number', description: 'Max elements to return (default: 50, use lower for speed)' },
-                            viewport_only: { type: 'boolean', description: 'Only visible elements (default: true)' }
-                        }
-                    }
-                },
-                {
-                    name: 'get_page_content',
-                    description: 'EXTRACTION: Get all readable text from the page. Use to read articles, extract information, or understand page content. Returns title + body text.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {}
-                    }
-                },
-                {
-                    name: 'wait_for_element',
-                    description: 'TIMING: Wait for an element to appear. Use after clicking if the next page/section loads dynamically. Essential for SPAs and AJAX-loaded content.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            selector: { type: 'string', description: 'CSS selector to wait for' },
-                            timeout: { type: 'number', description: 'Max wait time in ms (default: 5000)' }
-                        },
-                        required: ['selector']
-                    }
-                },
-                {
-                    name: 'type',
-                    description: 'INPUT: Type text character-by-character with delays (simulates human typing). Use when websites detect instant input as bots. For normal form filling, use "fill" instead (faster).',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            selector: { type: 'string', description: 'CSS selector of input field' },
-                            text: { type: 'string', description: 'Text to type' },
-                            delay: { type: 'number', description: 'Delay between keys in ms (default: 50)' }
-                        },
-                        required: ['selector', 'text']
-                    }
-                },
-                {
-                    name: 'select_option',
-                    description: 'INPUT: Choose an option from a <select> dropdown menu. REQUIRED: You MUST provide "selector" AND "value". Value should be the option value attribute or visible text.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            selector: { type: 'string', description: 'CSS selector of <select> element' },
-                            value: { type: 'string', description: 'Option value attribute OR visible text label' }
-                        },
-                        required: ['selector', 'value']
-                    }
-                },
-                {
-                    name: 'go_back',
-                    description: 'NAVIGATION: Click browser back button. Use to return to previous page after viewing details or search results.',
-                    inputSchema: { type: 'object', properties: {} }
-                },
-                {
-                    name: 'go_forward',
-                    description: 'NAVIGATION: Click browser forward button. Use after go_back to return to where you were.',
-                    inputSchema: { type: 'object', properties: {} }
-                },
-                {
-                    name: 'new_tab',
-                    description: 'TABS: Open a new browser tab. Use to keep current page open while checking another URL. Optionally provide URL to navigate immediately.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            url: { type: 'string', description: 'URL to open (optional - opens blank tab if omitted)' }
-                        }
-                    }
-                },
-                {
-                    name: 'switch_tab',
-                    description: 'TABS: Switch focus to a different tab. Use get_tabs first to see available tabs and their indices.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            index: { type: 'number', description: 'Tab index from get_tabs (0 = first tab)' }
-                        },
-                        required: ['index']
-                    }
-                },
-                {
-                    name: 'close_tab',
-                    description: 'TABS: Close the current tab. Automatically switches to another open tab. Cannot close the last remaining tab.',
-                    inputSchema: { type: 'object', properties: {} }
-                },
-                {
-                    name: 'get_tabs',
-                    description: 'TABS: List all open tabs with their index, title, and URL. Use before switch_tab to find the right tab.',
-                    inputSchema: { type: 'object', properties: {} }
-                },
-                {
-                    name: 'click_text',
-                    description: 'INTERACTION: Click by visible text - PREFERRED over "click" when you see text like "Login", "Submit", "Next". More reliable than CSS selectors. Use exact=true for buttons with common words.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            text: { type: 'string', description: 'Visible text on the element (e.g., "Sign In", "Add to Cart")' },
-                            exact: { type: 'boolean', description: 'true=exact match, false=partial match (default)' },
-                            tag: { type: 'string', description: 'Limit to tag type: button, a, div, span, etc.' }
-                        },
-                        required: ['text']
-                    }
-                },
-                {
-                    name: 'extract_data',
-                    description: 'EXTRACTION: Pull structured data from page. REQUIRED: "type" is mandatory. If type="custom", "fields" is also required.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            type: { type: 'string', enum: ['table', 'list', 'custom'], description: 'table=HTML table, list=ul/ol items, custom=define your own fields' },
-                            selector: { type: 'string', description: 'CSS selector of container (optional for table/list)' },
-                            fields: { type: 'object', description: 'For custom type: {"fieldName": "CSS selector", ...}' }
-                        },
-                        required: ['type']
-                    }
-                },
-                {
-                    name: 'upload_file',
-                    description: 'INPUT: Upload a file to a file input (<input type="file">). Use for document uploads, image uploads, CSV imports.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            selector: { type: 'string', description: 'CSS selector of file input element' },
-                            filePath: { type: 'string', description: 'Absolute path to file on disk' }
-                        },
-                        required: ['selector', 'filePath']
-                    }
-                },
-                {
-                    name: 'get_cookies',
-                    description: 'SESSION: Get all cookies for the current domain. Use to check login state, session tokens, or debug authentication issues.',
-                    inputSchema: { type: 'object', properties: {} }
-                },
-                {
-                    name: 'set_cookie',
-                    description: 'SESSION: Set a browser cookie. Use to maintain login sessions, set preferences, or bypass cookie consent (if legal).',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            name: { type: 'string', description: 'Cookie name' },
-                            value: { type: 'string', description: 'Cookie value' },
-                            domain: { type: 'string', description: 'Domain (defaults to current site)' },
-                            path: { type: 'string', description: 'Path scope (default: /)' }
-                        },
-                        required: ['name', 'value']
-                    }
-                },
-                {
-                    name: 'handle_dialog',
-                    description: 'DIALOGS: Handle JavaScript alert(), confirm(), or prompt() popups. Call BEFORE the action that triggers the dialog. Use accept for OK, dismiss for Cancel.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            action: { type: 'string', enum: ['accept', 'dismiss'], description: 'accept=click OK, dismiss=click Cancel' },
-                            promptText: { type: 'string', description: 'Text to enter if dialog is a prompt()' }
-                        },
-                        required: ['action']
-                    }
-                },
-                {
-                    name: 'switch_frame',
-                    description: 'ADVANCED: Switch context to an iframe (embedded page). Required for interacting with elements inside iframes. Omit selector to return to main page.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            selector: { type: 'string', description: 'CSS selector of iframe (omit to return to main frame)' }
-                        }
-                    }
-                },
-                {
-                    name: 'find_by_xpath',
-                    description: 'ADVANCED: Find elements using XPath expressions. Use when CSS cannot express the query (e.g., selecting by text content, parent-child relationships). Example: //button[contains(text(),"Submit")]',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            xpath: { type: 'string', description: 'XPath expression starting with //' },
-                            action: { type: 'string', enum: ['info', 'click', 'text'], description: 'info=element details, click=click first, text=get text content' }
-                        },
-                        required: ['xpath']
-                    }
-                },
-                {
-                    name: 'drag_drop',
-                    description: 'INTERACTION: Drag one element onto another. Use for sortable lists, kanban boards, file drop zones, slider handles.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            sourceSelector: { type: 'string', description: 'CSS selector of element to drag' },
-                            targetSelector: { type: 'string', description: 'CSS selector of drop destination' }
-                        },
-                        required: ['sourceSelector', 'targetSelector']
-                    }
-                },
-                {
-                    name: 'check_element',
-                    description: 'INSPECTION: Check element state without interacting. Use to verify if login succeeded (check welcome message), if item is in cart, if checkbox is checked, etc.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            selector: { type: 'string', description: 'CSS selector of element' },
-                            property: { type: 'string', description: 'exists, visible, text, value, href, src, checked, disabled, or any attribute name' }
-                        },
-                        required: ['selector']
-                    }
-                },
-                {
-                    name: 'set_viewport',
-                    description: 'CONFIG: Change browser window size. Use to test mobile layouts (375x667), tablets (768x1024), or desktop (1920x1080).',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            width: { type: 'number', description: 'Width in pixels' },
-                            height: { type: 'number', description: 'Height in pixels' }
-                        },
-                        required: ['width', 'height']
-                    }
-                },
-                {
-                    name: 'wait_for_navigation',
-                    description: 'TIMING: Wait for page to fully load after clicking a link. Use after actions that trigger page changes. Waits for network to be idle.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            timeout: { type: 'number', description: 'Max wait in ms (default: 30000)' }
-                        }
-                    }
-                },
-                {
-                    name: 'background_scrape',
-                    description: 'EXTRACTION: Silently opens a URL in a temporary headless browser, extracts data, and closes the browser immediately. Useful for quick fetch operations without disturbing the user\'s visible browser.',
-                    inputSchema: {
-                        type: 'object',
-                        properties: {
-                            url: { type: 'string', description: 'URL to scrape' },
-                            extractType: { type: 'string', enum: ['table', 'list', 'text'], description: 'What to extract: table, list, or text' },
-                            selector: { type: 'string', description: 'Optional CSS selector to target specific area' }
-                        },
-                        required: ['url', 'extractType']
-                    }
-                },
-                ...BROWSER_TURBO_SCHEMAS
-            ] as ToolSchema[]
-        };
+        // Auto-collect schemas from self-describing tools.
+        // Each tool owns its schema via getSchema(); aliases get copies with the aliased name.
+        const seen = new Set<string>();
+        const schemas: ToolSchema[] = [];
+
+        for (const tool of this.tools.values()) {
+            if (seen.has(tool.name)) continue;
+            seen.add(tool.name);
+
+            schemas.push(tool.getSchema());
+
+            // Publish alias schemas so the LLM can discover them
+            for (const alias of tool.aliases) {
+                schemas.push({ ...tool.getSchema(), name: alias });
+            }
+        }
+
+        return { tools: schemas };
     }
 
     /**

--- a/src/main/services/playwright/BrowserManager.ts
+++ b/src/main/services/playwright/BrowserManager.ts
@@ -56,8 +56,21 @@ export class BrowserManager {
     private headlessPage: Page | null = null;
     private headlessOverride: boolean | null = null;
 
+    private idleTimer: NodeJS.Timeout | null = null;
+    private readonly IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
     constructor() {
         this.store = new Store<Record<string, unknown>>();
+    }
+
+    private resetIdleTimer() {
+        if (this.idleTimer) {
+            clearTimeout(this.idleTimer);
+        }
+        this.idleTimer = setTimeout(() => {
+            console.log(`[BrowserManager] Closing browser after ${this.IDLE_TIMEOUT_MS / 60000} minutes of inactivity to save memory.`);
+            this.close().catch(e => console.error('[BrowserManager] Error during idle close:', e));
+        }, this.IDLE_TIMEOUT_MS);
     }
 
     /**
@@ -370,6 +383,8 @@ export class BrowserManager {
      * @returns A promise resolving to the active Page.
      */
     async getPage(args: any): Promise<Page> {
+        this.resetIdleTimer();
+
         // Handle headless mode execution request for background tools
         if (args && args._headless) {
             return this.ensureHeadlessPage();
@@ -418,6 +433,11 @@ export class BrowserManager {
      * Closes all browser contexts and resets internal tracking state.
      */
     async close() {
+        if (this.idleTimer) {
+            clearTimeout(this.idleTimer);
+            this.idleTimer = null;
+        }
+
         if (this.context) {
             await this.context.close();
             this.context = null;

--- a/src/main/services/playwright/PlaywrightTool.ts
+++ b/src/main/services/playwright/PlaywrightTool.ts
@@ -14,6 +14,7 @@
  */
 
 import { BrowserContext, Page } from 'playwright-core';
+import { ToolSchema } from '../../../shared/browser-tool-schemas';
 
 /**
  * The standard structure returned by all browser tools.
@@ -40,9 +41,26 @@ export interface PlaywrightContext {
 
 /**
  * Abstract base class for all Playwright-based interaction tools.
+ *
+ * Each tool is self-describing: it owns its name, schema, and optional aliases.
+ * PlaywrightService collects these at registration time — no manual duplication.
  */
 export abstract class PlaywrightTool {
     abstract name: string;
+
+    /**
+     * Optional alternate names this tool responds to.
+     * Example: NavigateTool declares `aliases = ['browser_navigate']`.
+     * PlaywrightService registers these automatically.
+     */
+    aliases: string[] = [];
+
+    /**
+     * Returns the MCP-compatible schema for this tool.
+     * This is the single source of truth for the tool's description and input shape.
+     */
+    abstract getSchema(): ToolSchema;
+
     /**
      * Executes the tool's core logic.
      *

--- a/src/main/services/playwright/tools/AdvancedTools.ts
+++ b/src/main/services/playwright/tools/AdvancedTools.ts
@@ -3,6 +3,22 @@ import { PlaywrightTool, ToolResult } from '../PlaywrightTool';
 
 export class EvaluateTool extends PlaywrightTool {
     name = 'evaluate';
+    aliases = ['browser_run_code'];
+
+    getSchema() {
+        return {
+            name: 'evaluate',
+            description: 'ADVANCED: Execute raw JavaScript code on the page. Use as a last resort when no other tool can accomplish the task. Can access DOM, modify page, or extract complex data. NOTE: document.querySelectorAll returns a NodeList, not Array. Use Array.from() before .map(), .filter(), or .slice(). if any issues occurs while executing the script, try to google the error and fix it.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    script: { type: 'string', description: 'JavaScript code to execute. Return value will be included in result.' }
+                },
+                required: ['script']
+            }
+        };
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         try {
             const result = await page.evaluate(args.script);
@@ -15,6 +31,22 @@ export class EvaluateTool extends PlaywrightTool {
 
 export class HandleDialogTool extends PlaywrightTool {
     name = 'handle_dialog';
+
+    getSchema() {
+        return {
+            name: 'handle_dialog',
+            description: 'DIALOGS: Handle JavaScript alert(), confirm(), or prompt() popups. Call BEFORE the action that triggers the dialog. Use accept for OK, dismiss for Cancel.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    action: { type: 'string', enum: ['accept', 'dismiss'], description: 'accept=click OK, dismiss=click Cancel' },
+                    promptText: { type: 'string', description: 'Text to enter if dialog is a prompt()' }
+                },
+                required: ['action']
+            }
+        };
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         const actionErr = this.requireParam(args, 'action');
         if (actionErr) return { result: null, error: actionErr };
@@ -32,6 +64,20 @@ export class HandleDialogTool extends PlaywrightTool {
 
 export class SwitchFrameTool extends PlaywrightTool {
     name = 'switch_frame';
+
+    getSchema() {
+        return {
+            name: 'switch_frame',
+            description: 'ADVANCED: Switch context to an iframe (embedded page). Required for interacting with elements inside iframes. Omit selector to return to main page.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    selector: { type: 'string', description: 'CSS selector of iframe (omit to return to main frame)' }
+                }
+            }
+        };
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         if (!args.selector) {
             return { result: 'Switched to main frame' };
@@ -50,6 +96,22 @@ export class SwitchFrameTool extends PlaywrightTool {
 
 export class FindByXpathTool extends PlaywrightTool {
     name = 'find_by_xpath';
+
+    getSchema() {
+        return {
+            name: 'find_by_xpath',
+            description: 'ADVANCED: Find elements using XPath expressions. Use when CSS cannot express the query (e.g., selecting by text content, parent-child relationships). Example: //button[contains(text(),"Submit")]',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    xpath: { type: 'string', description: 'XPath expression starting with //' },
+                    action: { type: 'string', enum: ['info', 'click', 'text'], description: 'info=element details, click=click first, text=get text content' }
+                },
+                required: ['xpath']
+            }
+        };
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         const xpErr = this.requireParam(args, 'xpath');
         if (xpErr) return { result: null, error: xpErr };
@@ -77,6 +139,22 @@ export class FindByXpathTool extends PlaywrightTool {
 
 export class CheckElementTool extends PlaywrightTool {
     name = 'check_element';
+
+    getSchema() {
+        return {
+            name: 'check_element',
+            description: 'INSPECTION: Check element state without interacting. Use to verify if login succeeded (check welcome message), if item is in cart, if checkbox is checked, etc.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    selector: { type: 'string', description: 'CSS selector of element' },
+                    property: { type: 'string', description: 'exists, visible, text, value, href, src, checked, disabled, or any attribute name' }
+                },
+                required: ['selector']
+            }
+        };
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         const selErr = this.requireParam(args, 'selector');
         if (selErr) return { result: null, error: selErr };
@@ -102,6 +180,22 @@ export class CheckElementTool extends PlaywrightTool {
 
 export class SetViewportTool extends PlaywrightTool {
     name = 'set_viewport';
+
+    getSchema() {
+        return {
+            name: 'set_viewport',
+            description: 'CONFIG: Change browser window size. Use to test mobile layouts (375x667), tablets (768x1024), or desktop (1920x1080).',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    width: { type: 'number', description: 'Width in pixels' },
+                    height: { type: 'number', description: 'Height in pixels' }
+                },
+                required: ['width', 'height']
+            }
+        };
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         const wErr = this.requireParam(args, 'width', 'number');
         if (wErr) return { result: null, error: wErr };

--- a/src/main/services/playwright/tools/ClickTextTool.ts
+++ b/src/main/services/playwright/tools/ClickTextTool.ts
@@ -4,6 +4,22 @@ import { PlaywrightTool, ToolResult } from '../PlaywrightTool';
 export class ClickTextTool extends PlaywrightTool {
     name = 'click_text';
 
+    getSchema() {
+        return {
+            name: 'click_text',
+            description: 'INTERACTION: Click by visible text - PREFERRED over "click" when you see text like "Login", "Submit", "Next". More reliable than CSS selectors. Use exact=true for buttons with common words.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    text: { type: 'string', description: 'Visible text on the element (e.g., "Sign In", "Add to Cart")' },
+                    exact: { type: 'boolean', description: 'true=exact match, false=partial match (default)' },
+                    tag: { type: 'string', description: 'Limit to tag type: button, a, div, span, etc.' }
+                },
+                required: ['text']
+            }
+        };
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         const textFindError = this.requireParam(args, 'text');
         if (textFindError) return { result: null, error: textFindError };

--- a/src/main/services/playwright/tools/ClickTool.ts
+++ b/src/main/services/playwright/tools/ClickTool.ts
@@ -4,6 +4,21 @@ import { humanizedClick } from '../humanMouse';
 
 export class ClickTool extends PlaywrightTool {
     name = 'click';
+    aliases = ['browser_click'];
+
+    getSchema() {
+        return {
+            name: 'click',
+            description: 'INTERACTION: Click an element using CSS selector. Use when you know the exact selector (e.g., "#submit-btn", ".login-button"). If you only know the text, use click_text instead.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    selector: { type: 'string', description: 'CSS selector like #id, .class, or tag[attr="value"]' }
+                },
+                required: ['selector']
+            }
+        };
+    }
 
     async execute(page: Page, args: any): Promise<ToolResult> {
         const clickError = this.requireParam(args, 'selector');

--- a/src/main/services/playwright/tools/ExtractionTools.ts
+++ b/src/main/services/playwright/tools/ExtractionTools.ts
@@ -1,8 +1,20 @@
-import { Page, chromium } from 'playwright-core';
+import { Page } from 'playwright-core';
 import { PlaywrightTool, ToolResult } from '../PlaywrightTool';
 
 export class GetPageContentTool extends PlaywrightTool {
     name = 'get_page_content';
+
+    getSchema() {
+        return {
+            name: 'get_page_content',
+            description: 'EXTRACTION: Get all readable text from the page. Use to read articles, extract information, or understand page content. Returns title + body text.',
+            inputSchema: {
+                type: 'object',
+                properties: {}
+            }
+        };
+    }
+
     async execute(page: Page): Promise<ToolResult> {
         const title = await page.title();
         const content = await page.evaluate(() => document.body.innerText);
@@ -12,6 +24,23 @@ export class GetPageContentTool extends PlaywrightTool {
 
 export class ExtractDataTool extends PlaywrightTool {
     name = 'extract_data';
+
+    getSchema() {
+        return {
+            name: 'extract_data',
+            description: 'EXTRACTION: Pull structured data from page. REQUIRED: "type" is mandatory. If type="custom", "fields" is also required.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    type: { type: 'string', enum: ['table', 'list', 'custom'], description: 'table=HTML table, list=ul/ol items, custom=define your own fields' },
+                    selector: { type: 'string', description: 'CSS selector of container (optional for table/list)' },
+                    fields: { type: 'object', description: 'For custom type: {"fieldName": "CSS selector", ...}' }
+                },
+                required: ['type']
+            }
+        };
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         const typeErr = this.requireParam(args, 'type');
         if (typeErr) return { result: null, error: typeErr };
@@ -53,21 +82,36 @@ export class ExtractDataTool extends PlaywrightTool {
 
 export class BackgroundScrapeTool extends PlaywrightTool {
     name = 'background_scrape';
-    async execute(_page: Page, args: any): Promise<ToolResult> {
+
+    getSchema() {
+        return {
+            name: 'background_scrape',
+            description: 'EXTRACTION: Silently opens a URL in a temporary headless browser, extracts data, and closes the browser immediately. Useful for quick fetch operations without disturbing the user\'s visible browser.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    url: { type: 'string', description: 'URL to scrape' },
+                    extractType: { type: 'string', enum: ['table', 'list', 'text'], description: 'What to extract: table, list, or text' },
+                    selector: { type: 'string', description: 'Optional CSS selector to target specific area' }
+                },
+                required: ['url', 'extractType']
+            }
+        };
+    }
+
+    async execute(page: Page, args: any): Promise<ToolResult> {
         const bgUrlErr = this.requireParam(args, 'url');
         if (bgUrlErr) return { result: null, error: bgUrlErr };
         const bgTypeErr = this.requireParam(args, 'extractType');
         if (bgTypeErr) return { result: null, error: bgTypeErr };
 
-        console.log(`[PlaywrightService] Starting temp headless browser for background scrape...`);
-        const tempBrowser = await chromium.launch({ headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu', '--disable-dev-shm-usage'] });
+        console.log(`[BackgroundScrapeTool] Using managed headless session for URL: ${args.url}`);
         try {
-            const tempPage = await tempBrowser.newPage();
-            await tempPage.goto(args.url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+            await page.goto(args.url, { waitUntil: 'domcontentloaded', timeout: 30000 });
 
             let data: any = null;
             if (args.extractType === 'table') {
-                data = await tempPage.evaluate((sel: string | undefined) => {
+                data = await page.evaluate((sel: string | undefined) => {
                     const table = sel ? document.querySelector(sel) : document.querySelector('table');
                     if (!table) return null;
                     const rows: string[][] = [];
@@ -79,7 +123,7 @@ export class BackgroundScrapeTool extends PlaywrightTool {
                     return rows;
                 }, args.selector);
             } else if (args.extractType === 'list') {
-                data = await tempPage.evaluate((sel: string | undefined) => {
+                data = await page.evaluate((sel: string | undefined) => {
                     const list = sel ? document.querySelector(sel) : document.querySelector('ul, ol');
                     if (!list) return null;
                     const items: string[] = [];
@@ -87,7 +131,7 @@ export class BackgroundScrapeTool extends PlaywrightTool {
                     return items;
                 }, args.selector);
             } else {
-                data = await tempPage.evaluate((sel: string | undefined) => {
+                data = await page.evaluate((sel: string | undefined) => {
                     const el = sel ? document.querySelector(sel) : document.body;
                     return el ? (el as HTMLElement).innerText.trim() : null;
                 }, args.selector);
@@ -99,8 +143,6 @@ export class BackgroundScrapeTool extends PlaywrightTool {
             return { result: { type: args.extractType, data } };
         } catch (err: any) {
             return { result: null, error: err.message || String(err) };
-        } finally {
-            await tempBrowser.close();
         }
     }
 }

--- a/src/main/services/playwright/tools/FillTool.ts
+++ b/src/main/services/playwright/tools/FillTool.ts
@@ -3,6 +3,22 @@ import { PlaywrightTool, ToolResult } from '../PlaywrightTool';
 
 export class FillTool extends PlaywrightTool {
     name = 'fill';
+    aliases = ['browser_fill'];
+
+    getSchema() {
+        return {
+            name: 'fill',
+            description: 'INPUT: Instantly fill a text input, textarea, or contenteditable field. Use for forms, search boxes, login fields. Replaces existing content. For character-by-character typing, use "type" instead.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    selector: { type: 'string', description: 'CSS selector of the input field' },
+                    value: { type: 'string', description: 'Text to enter' }
+                },
+                required: ['selector', 'value']
+            }
+        };
+    }
 
     async execute(page: Page, args: any): Promise<ToolResult> {
         const selectorError = this.requireParam(args, 'selector');

--- a/src/main/services/playwright/tools/GetInteractiveElementsTool.ts
+++ b/src/main/services/playwright/tools/GetInteractiveElementsTool.ts
@@ -4,6 +4,20 @@ import { PlaywrightTool, ToolResult } from '../PlaywrightTool';
 export class GetInteractiveElementsTool extends PlaywrightTool {
     name = 'get_interactive_elements';
 
+    getSchema() {
+        return {
+            name: 'get_interactive_elements',
+            description: 'PERCEPTION: Get a compact list of clickable elements (buttons, links, inputs) with their text and selectors. FASTEST way to understand page structure. Use this to find what to click.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    limit: { type: 'number', description: 'Max elements to return (default: 50, use lower for speed)' },
+                    viewport_only: { type: 'boolean', description: 'Only visible elements (default: true)' }
+                }
+            }
+        };
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         const limit = args.limit || 50;
         const viewportOnly = args.viewport_only !== false;

--- a/src/main/services/playwright/tools/GetStateTool.ts
+++ b/src/main/services/playwright/tools/GetStateTool.ts
@@ -16,6 +16,23 @@ import { PlaywrightTool, ToolResult } from '../PlaywrightTool';
  */
 export class GetStateTool extends PlaywrightTool {
     name = 'get_state';
+    aliases = ['browser_snapshot'];
+
+    getSchema() {
+        return {
+            name: 'get_state',
+            description: 'PERCEPTION: Understand what is on the current page. Use this AFTER navigation to see page elements. Modes: "fast"=quick text list (recommended), "full"=detailed DOM tree, "vision"=screenshot with labeled elements.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    mode: { type: 'string', enum: ['fast', 'full', 'vision'], description: 'fast=elements only (fastest, lowest tokens), full=elements+DOM tree, vision=screenshot+numbered elements' },
+                    screenshot: { type: 'boolean', description: 'Force include screenshot (auto in vision mode)' },
+                    tree: { type: 'boolean', description: 'Force include DOM tree (auto in full mode)' },
+                    highlight: { type: 'boolean', description: 'Draw numbered boxes on interactive elements in screenshot' }
+                }
+            }
+        };
+    }
 
     async execute(page: Page, args: any): Promise<ToolResult> {
         const mode = args.mode || 'fast';

--- a/src/main/services/playwright/tools/InputTools.ts
+++ b/src/main/services/playwright/tools/InputTools.ts
@@ -3,6 +3,22 @@ import { PlaywrightTool, ToolResult } from '../PlaywrightTool';
 
 export class SelectOptionTool extends PlaywrightTool {
     name = 'select_option';
+
+    getSchema() {
+        return {
+            name: 'select_option',
+            description: 'INPUT: Choose an option from a <select> dropdown menu. REQUIRED: You MUST provide "selector" AND "value". Value should be the option value attribute or visible text.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    selector: { type: 'string', description: 'CSS selector of <select> element' },
+                    value: { type: 'string', description: 'Option value attribute OR visible text label' }
+                },
+                required: ['selector', 'value']
+            }
+        };
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         const selErr = this.requireParam(args, 'selector');
         if (selErr) return { result: null, error: selErr };
@@ -16,6 +32,22 @@ export class SelectOptionTool extends PlaywrightTool {
 
 export class UploadFileTool extends PlaywrightTool {
     name = 'upload_file';
+
+    getSchema() {
+        return {
+            name: 'upload_file',
+            description: 'INPUT: Upload a file to a file input (<input type="file">). Use for document uploads, image uploads, CSV imports.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    selector: { type: 'string', description: 'CSS selector of file input element' },
+                    filePath: { type: 'string', description: 'Absolute path to file on disk' }
+                },
+                required: ['selector', 'filePath']
+            }
+        };
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         const selErr = this.requireParam(args, 'selector');
         if (selErr) return { result: null, error: selErr };
@@ -29,6 +61,21 @@ export class UploadFileTool extends PlaywrightTool {
 
 export class HoverTool extends PlaywrightTool {
     name = 'hover';
+
+    getSchema() {
+        return {
+            name: 'hover',
+            description: 'INTERACTION: Move mouse over an element without clicking. Use to reveal dropdown menus, tooltips, or trigger hover states before clicking sub-items.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    selector: { type: 'string', description: 'CSS selector of element to hover' }
+                },
+                required: ['selector']
+            }
+        };
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         const selErr = this.requireParam(args, 'selector');
         if (selErr) return { result: null, error: selErr };
@@ -39,6 +86,22 @@ export class HoverTool extends PlaywrightTool {
 
 export class PressTool extends PlaywrightTool {
     name = 'press';
+    aliases = ['browser_press_key'];
+
+    getSchema() {
+        return {
+            name: 'press',
+            description: 'KEYBOARD: Press a single key. Use for Enter (submit forms), Escape (close dialogs), Tab (navigate fields), ArrowDown/Up (navigate lists). Common keys: Enter, Escape, Tab, Space, Backspace, ArrowUp/Down/Left/Right.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    key: { type: 'string', description: 'Key name: Enter, Escape, Tab, Space, ArrowDown, etc.' }
+                },
+                required: ['key']
+            }
+        };
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         const keyErr = this.requireParam(args, 'key');
         if (keyErr) return { result: null, error: keyErr };
@@ -49,6 +112,22 @@ export class PressTool extends PlaywrightTool {
 
 export class ScrollTool extends PlaywrightTool {
     name = 'scroll';
+
+    getSchema() {
+        return {
+            name: 'scroll',
+            description: 'NAVIGATION: Scroll the page to see more content. Use "down" to load more items, "top" to return to beginning, "bottom" to reach footer/end of page.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    direction: { type: 'string', enum: ['up', 'down', 'top', 'bottom'], description: 'up/down=scroll by amount, top/bottom=jump to edge' },
+                    amount: { type: 'number', description: 'Pixels to scroll (default: 500). Only used for up/down.' }
+                },
+                required: ['direction']
+            }
+        };
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         const dirErr = this.requireParam(args, 'direction');
         if (dirErr) return { result: null, error: dirErr };
@@ -64,6 +143,22 @@ export class ScrollTool extends PlaywrightTool {
 
 export class DragDropTool extends PlaywrightTool {
     name = 'drag_drop';
+
+    getSchema() {
+        return {
+            name: 'drag_drop',
+            description: 'INTERACTION: Drag one element onto another. Use for sortable lists, kanban boards, file drop zones, slider handles.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    sourceSelector: { type: 'string', description: 'CSS selector of element to drag' },
+                    targetSelector: { type: 'string', description: 'CSS selector of drop destination' }
+                },
+                required: ['sourceSelector', 'targetSelector']
+            }
+        };
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         const srcErr = this.requireParam(args, 'sourceSelector');
         if (srcErr) return { result: null, error: srcErr };

--- a/src/main/services/playwright/tools/MiscTools.ts
+++ b/src/main/services/playwright/tools/MiscTools.ts
@@ -11,6 +11,15 @@ import { PlaywrightTool, ToolResult } from '../PlaywrightTool';
 
 export class GoBackTool extends PlaywrightTool {
     name = 'go_back';
+
+    getSchema() {
+        return {
+            name: 'go_back',
+            description: 'NAVIGATION: Click browser back button. Use to return to previous page after viewing details or search results.',
+            inputSchema: { type: 'object', properties: {} }
+        };
+    }
+
     async execute(page: Page): Promise<ToolResult> {
         await page.goBack();
         return { result: 'Navigated back' };
@@ -19,6 +28,15 @@ export class GoBackTool extends PlaywrightTool {
 
 export class GoForwardTool extends PlaywrightTool {
     name = 'go_forward';
+
+    getSchema() {
+        return {
+            name: 'go_forward',
+            description: 'NAVIGATION: Click browser forward button. Use after go_back to return to where you were.',
+            inputSchema: { type: 'object', properties: {} }
+        };
+    }
+
     async execute(page: Page): Promise<ToolResult> {
         await page.goForward();
         return { result: 'Navigated forward' };
@@ -27,6 +45,20 @@ export class GoForwardTool extends PlaywrightTool {
 
 export class WaitForNavigationTool extends PlaywrightTool {
     name = 'wait_for_navigation';
+
+    getSchema() {
+        return {
+            name: 'wait_for_navigation',
+            description: 'TIMING: Wait for page to fully load after clicking a link. Use after actions that trigger page changes. Waits for network to be idle.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    timeout: { type: 'number', description: 'Max wait in ms (default: 30000)' }
+                }
+            }
+        };
+    }
+
     async execute(page: Page | Frame, args: any): Promise<ToolResult> {
         await page.waitForLoadState('networkidle', {
             timeout: args.timeout || 10000

--- a/src/main/services/playwright/tools/NavigateTool.ts
+++ b/src/main/services/playwright/tools/NavigateTool.ts
@@ -15,6 +15,7 @@ import { PlaywrightTool, ToolResult } from '../PlaywrightTool';
  */
 export class NavigateTool extends PlaywrightTool {
     name = 'navigate';
+    aliases = ['browser_navigate'];
 
     async execute(page: Page, args: any): Promise<ToolResult> {
         const navError = this.requireParam(args, 'url');

--- a/src/main/services/playwright/tools/ScreenshotTool.ts
+++ b/src/main/services/playwright/tools/ScreenshotTool.ts
@@ -4,6 +4,18 @@ import { PlaywrightTool, ToolResult } from '../PlaywrightTool';
 export class ScreenshotTool extends PlaywrightTool {
     name = 'screenshot';
 
+    getSchema() {
+        return {
+            name: 'screenshot',
+            description: 'VISION: Capture the current page as an image. Use when you need to see the page visually or save visual evidence. For perceiving page state, prefer get_state instead.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    fullPage: { type: 'boolean', description: 'true=capture entire scrollable page, false=visible viewport only' }
+                }
+            }
+        };
+    }
     async execute(page: Page, args: any): Promise<ToolResult> {
         const buffer = await page.screenshot({ fullPage: args.fullPage || false });
         return {

--- a/src/main/services/playwright/tools/SessionTools.ts
+++ b/src/main/services/playwright/tools/SessionTools.ts
@@ -1,8 +1,18 @@
 import { Page } from 'playwright-core';
 import { PlaywrightTool, ToolResult, PlaywrightContext } from '../PlaywrightTool';
+import { REQUEST_HUMAN_INTERVENTION_SCHEMA } from '../../../../shared/browser-tool-schemas';
 
 export class GetCookiesTool extends PlaywrightTool {
     name = 'get_cookies';
+
+    getSchema() {
+        return {
+            name: 'get_cookies',
+            description: 'SESSION: Get all cookies for the current domain. Use to check login state, session tokens, or debug authentication issues.',
+            inputSchema: { type: 'object', properties: {} }
+        };
+    }
+
     async execute(_page: Page, _args: any, context?: PlaywrightContext): Promise<ToolResult> {
         if (!context?.context) throw new Error('No browser context');
         const cookies = await context.context.cookies();
@@ -12,6 +22,24 @@ export class GetCookiesTool extends PlaywrightTool {
 
 export class SetCookieTool extends PlaywrightTool {
     name = 'set_cookie';
+
+    getSchema() {
+        return {
+            name: 'set_cookie',
+            description: 'SESSION: Set a browser cookie. Use to maintain login sessions, set preferences, or bypass cookie consent (if legal).',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    name: { type: 'string', description: 'Cookie name' },
+                    value: { type: 'string', description: 'Cookie value' },
+                    domain: { type: 'string', description: 'Domain (defaults to current site)' },
+                    path: { type: 'string', description: 'Path scope (default: /)' }
+                },
+                required: ['name', 'value']
+            }
+        };
+    }
+
     async execute(page: Page, args: any, context?: PlaywrightContext): Promise<ToolResult> {
         if (!context?.context) throw new Error('No browser context');
 
@@ -36,6 +64,11 @@ export class SetCookieTool extends PlaywrightTool {
 
 export class RequestHumanInterventionTool extends PlaywrightTool {
     name = 'request_human_intervention';
+
+    getSchema() {
+        return REQUEST_HUMAN_INTERVENTION_SCHEMA;
+    }
+
     async execute(_page: Page, args: any, context?: PlaywrightContext): Promise<ToolResult> {
         const rErr = this.requireParam(args, 'reason');
         if (rErr) return { result: null, error: rErr };

--- a/src/main/services/playwright/tools/TabTools.ts
+++ b/src/main/services/playwright/tools/TabTools.ts
@@ -16,6 +16,20 @@ import { PlaywrightTool, ToolResult, PlaywrightContext } from '../PlaywrightTool
  */
 export class NewTabTool extends PlaywrightTool {
     name = 'new_tab';
+
+    getSchema() {
+        return {
+            name: 'new_tab',
+            description: 'TABS: Open a new browser tab. Use to keep current page open while checking another URL. Optionally provide URL to navigate immediately.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    url: { type: 'string', description: 'URL to open (optional - opens blank tab if omitted)' }
+                }
+            }
+        };
+    }
+
     async execute(_page: Page, args: any, context?: PlaywrightContext): Promise<ToolResult> {
         if (!context?.context) throw new Error('No browser context');
         const newPage = await context.context.newPage();
@@ -33,6 +47,21 @@ export class NewTabTool extends PlaywrightTool {
  */
 export class SwitchTabTool extends PlaywrightTool {
     name = 'switch_tab';
+
+    getSchema() {
+        return {
+            name: 'switch_tab',
+            description: 'TABS: Switch focus to a different tab. Use get_tabs first to see available tabs and their indices.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    index: { type: 'number', description: 'Tab index from get_tabs (0 = first tab)' }
+                },
+                required: ['index']
+            }
+        };
+    }
+
     async execute(_page: Page, args: any, context?: PlaywrightContext): Promise<ToolResult> {
         if (!context) throw new Error('No playwright context');
         const targetTab = context.pagesMap.get(args.index);
@@ -50,6 +79,15 @@ export class SwitchTabTool extends PlaywrightTool {
  */
 export class CloseTabTool extends PlaywrightTool {
     name = 'close_tab';
+
+    getSchema() {
+        return {
+            name: 'close_tab',
+            description: 'TABS: Close the current tab. Automatically switches to another open tab. Cannot close the last remaining tab.',
+            inputSchema: { type: 'object', properties: {} }
+        };
+    }
+
     async execute(page: Page, _args: any, context?: PlaywrightContext): Promise<ToolResult> {
         if (!context?.context) throw new Error('No browser context');
         // If args.tabId or args.index is provided, use that, otherwise use current page
@@ -79,6 +117,15 @@ export class CloseTabTool extends PlaywrightTool {
  */
 export class GetTabsTool extends PlaywrightTool {
     name = 'get_tabs';
+
+    getSchema() {
+        return {
+            name: 'get_tabs',
+            description: 'TABS: List all open tabs with their index, title, and URL. Use before switch_tab to find the right tab.',
+            inputSchema: { type: 'object', properties: {} }
+        };
+    }
+
     async execute(_page: Page, _args: any, context?: PlaywrightContext): Promise<ToolResult> {
         if (!context) throw new Error('No playwright context');
         const tabList = await Promise.all(

--- a/src/main/services/playwright/tools/TurboTools.ts
+++ b/src/main/services/playwright/tools/TurboTools.ts
@@ -1,8 +1,13 @@
 import { Page } from 'playwright-core';
 import { PlaywrightTool, ToolResult, PlaywrightContext } from '../PlaywrightTool';
+import { BROWSER_ACTION_SEQUENCE_SCHEMA, WEB_SEARCH_SCHEMA, FILL_FORM_SCHEMA } from '../../../../shared/browser-tool-schemas';
 
 export class BrowserActionSequenceTool extends PlaywrightTool {
     name = 'browser_action_sequence';
+
+    getSchema() {
+        return BROWSER_ACTION_SEQUENCE_SCHEMA;
+    }
 
     async execute(page: Page, args: any, context?: PlaywrightContext): Promise<ToolResult> {
         if (!context) throw new Error('No playwright context');
@@ -75,6 +80,10 @@ export class BrowserActionSequenceTool extends PlaywrightTool {
 export class WebSearchTool extends PlaywrightTool {
     name = 'web_search';
 
+    getSchema() {
+        return WEB_SEARCH_SCHEMA;
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         const query = args.query;
         if (!query) return { result: null, error: 'web_search: query is required' };
@@ -127,6 +136,10 @@ export class WebSearchTool extends PlaywrightTool {
 
 export class FillFormTool extends PlaywrightTool {
     name = 'fill_form';
+
+    getSchema() {
+        return FILL_FORM_SCHEMA;
+    }
 
     async execute(page: Page, args: any, context?: PlaywrightContext): Promise<ToolResult> {
         if (!context) throw new Error('No playwright context');

--- a/src/main/services/playwright/tools/TypeTool.ts
+++ b/src/main/services/playwright/tools/TypeTool.ts
@@ -4,6 +4,23 @@ import { humanizedClick } from '../humanMouse';
 
 export class TypeTool extends PlaywrightTool {
     name = 'type';
+    aliases = ['browser_type'];
+
+    getSchema() {
+        return {
+            name: 'type',
+            description: 'INPUT: Type text character-by-character with delays (simulates human typing). Use when websites detect instant input as bots. For normal form filling, use "fill" instead (faster).',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    selector: { type: 'string', description: 'CSS selector of input field' },
+                    text: { type: 'string', description: 'Text to type' },
+                    delay: { type: 'number', description: 'Delay between keys in ms (default: 50)' }
+                },
+                required: ['selector', 'text']
+            }
+        };
+    }
 
     async execute(page: Page, args: any): Promise<ToolResult> {
         const selectorError = this.requireParam(args, 'selector');

--- a/src/main/services/playwright/tools/WaitForElementTool.ts
+++ b/src/main/services/playwright/tools/WaitForElementTool.ts
@@ -4,6 +4,21 @@ import { PlaywrightTool, ToolResult } from '../PlaywrightTool';
 export class WaitForElementTool extends PlaywrightTool {
     name = 'wait_for_element';
 
+    getSchema() {
+        return {
+            name: 'wait_for_element',
+            description: 'TIMING: Wait for an element to appear. Use after clicking if the next page/section loads dynamically. Essential for SPAs and AJAX-loaded content.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    selector: { type: 'string', description: 'CSS selector to wait for' },
+                    timeout: { type: 'number', description: 'Max wait time in ms (default: 5000)' }
+                },
+                required: ['selector']
+            }
+        };
+    }
+
     async execute(page: Page, args: any): Promise<ToolResult> {
         const originalSelector = args.selector;
         const timeout = args.timeout || 5000;

--- a/src/renderer/src/lib/agent-runtime.ts
+++ b/src/renderer/src/lib/agent-runtime.ts
@@ -104,6 +104,10 @@ export class AgentRuntime implements IAgentClient {
   private specialHandlers: SpecialToolHandlers;
   /** Tracks last emitted progress % for incremental orchestration ticks */
   private _lastProgressPct = 0;
+  /** Incremental estimate of context size in bytes — avoids JSON.stringify on every iteration */
+  private _estimatedContextBytes = 0;
+  /** Counter to trigger periodic full context resync */
+  private _contextResyncCounter = 0;
 
   constructor(options: AgentRuntimeOptions, initialHistory: LLMMessage[] = []) {
     this.options = options;
@@ -603,8 +607,15 @@ export class AgentRuntime implements IAgentClient {
   // ── Private: Helpers ───────────────────────────────────────────────────────
 
   private async _handleContextLimits() {
-    const contextText = JSON.stringify(this.messages);
-    const estimatedTokens = Math.ceil(contextText.length / 4);
+    this._contextResyncCounter++;
+
+    // Full resync every 10 iterations as a safety net
+    if (this._contextResyncCounter % 10 === 0) {
+      const contextText = JSON.stringify(this.messages);
+      this._estimatedContextBytes = contextText.length;
+    }
+
+    const estimatedTokens = Math.ceil(this._estimatedContextBytes / 4);
     const contextLimit = 100000;
     if (estimatedTokens > contextLimit * 0.8 && !this.options.isSubAgent) {
       const originalGoalMsg = this.messages.find((m) => m.role === "user");
@@ -720,6 +731,9 @@ export class AgentRuntime implements IAgentClient {
 
   private addMessage(msg: LLMMessage): string | void {
     this.messages.push(msg);
+    // Incrementally track context size (avoid full JSON.stringify)
+    const contentLen = typeof msg.content === 'string' ? msg.content.length : JSON.stringify(msg.content ?? '').length;
+    this._estimatedContextBytes += contentLen + 50; // +50 for role, metadata overhead
     return this.options.onMessage?.(msg);
   }
 

--- a/src/renderer/src/lib/agent/ToolExecutionService.ts
+++ b/src/renderer/src/lib/agent/ToolExecutionService.ts
@@ -22,6 +22,8 @@
 import { executeToolCall } from "../mcp";
 import { analyzeToolOutput } from "../result-reporter";
 import { type LLMMessage } from "../types";
+import { laneManager } from "../execution-lanes";
+import { STATEFUL_BROWSER_TOOLS } from "../client-tools";
 
 // ── Constants ──────────────────────────────────────────────────────────────────
 
@@ -181,10 +183,6 @@ async function _executeWithRetry(
     }
 
     try {
-        // ── Dynamic imports (lazy, to keep initial bundle small) ─────────────────
-        const { laneManager } = await import("../execution-lanes");
-        const { STATEFUL_BROWSER_TOOLS } = await import("../client-tools");
-
         // ── Tab isolation: inject tabId for browser tools ─────────────────────────
         // WHY: Parallel sub-agents each get a dedicated tab. Injecting tabId here
         // ensures all browser tool calls from this agent stay in their own tab.

--- a/src/renderer/src/lib/dcp.ts
+++ b/src/renderer/src/lib/dcp.ts
@@ -14,42 +14,28 @@ import { LLMMessage } from "./types";
  * than the most recent one).
  */
 export function pruneContext(messages: LLMMessage[]): LLMMessage[] {
-  // 1. Map tool_call_id to its definition (name + args)
   const toolCallDefinitions = new Map<string, string>();
-  
-  for (const msg of messages) {
-    if (msg.role === 'assistant' && msg.tool_calls) {
-      for (const call of msg.tool_calls) {
-        // Create a unique signature for this tool call configuration
-        // We sort keys to ensure arguments object order doesn't matter
-        const argsStr = JSON.stringify(call.function.arguments || {}, Object.keys(call.function.arguments || {}).sort());
-        const signature = `${call.function.name}:${argsStr}`;
-        toolCallDefinitions.set(call.id, signature);
-      }
-    }
-  }
-
-  // 2. Find which definitions have been executed multiple times
-  // We want to know the *last* tool_call_id for each signature
   const signatureToLastId = new Map<string, string>();
-  const allIdsForSignature = new Map<string, string[]>();
+  const allIdsForSignature = new Map<string, Set<string>>();
 
-  // Iterate in order to find the last one
-  // (We rely on toolCallDefinitions being populated in order, or we scan messages again? 
-  //  Actually, we can just use the map we built, but we need to know the order of occurrence in messages)
-  
-  // Let's re-scan messages to be safe about order
-  for (const msg of messages) {
+  // 1 & 2. Single pass: Map tool_call_id to signature, and track all IDs per signature
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
     if (msg.role === 'assistant' && msg.tool_calls) {
       for (const call of msg.tool_calls) {
-        const signature = toolCallDefinitions.get(call.id);
-        if (signature) {
-          signatureToLastId.set(signature, call.id);
-          
-          const existing = allIdsForSignature.get(signature) || [];
-          existing.push(call.id);
-          allIdsForSignature.set(signature, existing);
+        // Fast signature (we omit sorting keys for speed, LLM output is usually consistent)
+        const argsStr = JSON.stringify(call.function.arguments || {});
+        const signature = `${call.function.name}:${argsStr}`;
+        
+        toolCallDefinitions.set(call.id, signature);
+        signatureToLastId.set(signature, call.id);
+
+        let ids = allIdsForSignature.get(signature);
+        if (!ids) {
+            ids = new Set();
+            allIdsForSignature.set(signature, ids);
         }
+        ids.add(call.id);
       }
     }
   }
@@ -58,7 +44,7 @@ export function pruneContext(messages: LLMMessage[]): LLMMessage[] {
   const idsToPrune = new Set<string>();
   
   for (const [signature, ids] of allIdsForSignature.entries()) {
-    if (ids.length > 1) {
+    if (ids.size > 1) {
       // Keep the last one, prune the rest
       const lastId = signatureToLastId.get(signature);
       for (const id of ids) {
@@ -69,17 +55,27 @@ export function pruneContext(messages: LLMMessage[]): LLMMessage[] {
     }
   }
 
-  // 4. Create new messages array with pruned content
-  return messages.map((msg) => {
-    // We only modify messages with role 'tool'
-    if (msg.role === 'tool' && msg.tool_call_id) {
-      if (idsToPrune.has(msg.tool_call_id)) {
-        return {
-          ...msg,
-          content: "[Redundant Tool Output Pruned by DCP]",
-        };
+  // FAST PATH: If nothing to prune, return the original array reference!
+  // This saves massive GC churn and React re-renders since the array identity stays exactly the same.
+  if (idsToPrune.size === 0) {
+      return messages;
+  }
+
+  // 4. Create new messages array with pruned content, ONLY if we actually change something
+  let changed = false;
+  const newMessages = messages.map((msg) => {
+    if (msg.role === 'tool' && msg.tool_call_id && idsToPrune.has(msg.tool_call_id)) {
+      if (msg.content === "[Redundant Tool Output Pruned by DCP]") {
+          return msg; // Already pruned previously
       }
+      changed = true;
+      return {
+        ...msg,
+        content: "[Redundant Tool Output Pruned by DCP]",
+      };
     }
     return msg;
   });
+
+  return changed ? newMessages : messages;
 }

--- a/src/renderer/src/lib/execution-lanes.ts
+++ b/src/renderer/src/lib/execution-lanes.ts
@@ -146,26 +146,22 @@ export class LaneManager {
 
     // Standard Lanes
     private globalBrowserLane: LaneQueue;
-    // private apiParallelLane: LaneQueue; // COMMENTED OUT - not using API parallel lane
-    private fileSystemLane: LaneQueue; // Granular locking handled inside? Or just serial?
-    // Current design: FS tools use a granular lock in the old code. 
-    // Here we can make a high-concurrency lane, but we might need KeyedMutex if we want true file-level locking.
-    // For now, let's stick to the Plan: Serial Browser, Parallel API.
+    private apiParallelLane: LaneQueue;
+    private fileSystemLane: LaneQueue;
 
     constructor() {
         // Browser: Serial (1 at a time) to prevent race conditions on the active page
         this.globalBrowserLane = new LaneQueue('BROWSER_SERIAL', 1);
 
-        // API/Thinking: Parallel (High concurrency)
-        // COMMENTED OUT: Not using API parallel lane for now - everything goes through browser serial
-        // this.apiParallelLane = new LaneQueue('API_PARALLEL', 10);
+        // API/Thinking: Parallel (High concurrency) for stateless tools
+        // like memory_retrieve, sequential-thinking, search, etc.
+        this.apiParallelLane = new LaneQueue('API_PARALLEL', 10);
 
-        // FileSystem: For now, we'll allow parallel file ops (OS handles locking mostly, or we assume different files)
-        // If we need strict file locking, we'd add it here.
+        // FileSystem: Parallel file ops (OS handles locking, tools target different files)
         this.fileSystemLane = new LaneQueue('FILESYSTEM', 5);
 
         this.lanes.set(this.globalBrowserLane.id, this.globalBrowserLane);
-        // this.lanes.set(this.apiParallelLane.id, this.apiParallelLane); // COMMENTED OUT
+        this.lanes.set(this.apiParallelLane.id, this.apiParallelLane);
         this.lanes.set(this.fileSystemLane.id, this.fileSystemLane);
     }
 
@@ -223,12 +219,9 @@ export class LaneManager {
             return this.fileSystemLane;
         }
 
-        // 3. Stateless/API Tools (Memory, Search, etc.)
-        // COMMENTED OUT: Forcing all non-browser/file tools to use browser lane for now
-        // return this.apiParallelLane;
-
-        // TEMPORARY: Route everything to browser serial to prevent race conditions
-        return this.globalBrowserLane;
+        // 3. Stateless/API Tools (Memory, Search, Sequential Thinking, etc.)
+        // These have no side effects and can safely run in parallel.
+        return this.apiParallelLane;
     }
 
     // Debugging helper

--- a/src/renderer/src/lib/experiments/experimentProvider.tsx
+++ b/src/renderer/src/lib/experiments/experimentProvider.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 /**
  * experimentProvider.tsx — React context + declarative A/B testing components.
  *

--- a/src/renderer/src/lib/featureFlags.ts
+++ b/src/renderer/src/lib/featureFlags.ts
@@ -17,8 +17,7 @@ export function isDevelopmentMode(): boolean {
   return (
     process.env.NODE_ENV === 'development' ||
     process.env.ELECTRON_IS_DEV === '1' ||
-    (window as any).electron?.isDev ||
-    // @ts-ignore - electron-toolkit utils
+    (window as unknown as { electron?: { isDev?: boolean } })?.electron?.isDev ||
     (window.require && window.require('@electron-toolkit/utils')?.is?.dev) ||
     window.location.hostname === 'localhost' ||
     window.location.port !== ''

--- a/src/renderer/src/lib/mcp.ts
+++ b/src/renderer/src/lib/mcp.ts
@@ -105,6 +105,29 @@ function ensureRecord(args: Record<string, unknown> | null | undefined): Record<
 }
 
 // Execute a tool call with retry logic for connection errors
+
+// ── MCP Idle Disconnect Timers ──────────────────────────────────────────────────
+// Automatically disconnect backend processes (Node/Python) after 10m of inactivity
+// to ensure idle agents don't consume gigabytes of background RAM.
+const mcpIdleTimers = new Map<string, NodeJS.Timeout>();
+const MCP_IDLE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+
+function resetMcpIdleTimer(serverId: string, serverName: string) {
+  const existing = mcpIdleTimers.get(serverId);
+  if (existing) clearTimeout(existing);
+
+  const timer = setTimeout(async () => {
+    logMcpRenderer("info", `Disconnecting server ${serverName} due to ${MCP_IDLE_TIMEOUT_MS / 60000}m of inactivity...`, { serverId, serverName });
+    try {
+      await disconnectServer(serverId);
+    } catch (err) {
+      logMcpRenderer("warn", `Failed to idle-disconnect server ${serverName}`, { error: String(err) });
+    }
+  }, MCP_IDLE_TIMEOUT_MS);
+
+  mcpIdleTimers.set(serverId, timer);
+}
+
 export async function executeToolCall(
   toolName: string,
   args: Record<string, unknown> | null | undefined
@@ -233,6 +256,29 @@ export async function executeToolCall(
     };
   }
 
+  // LAZY CONNECT: If the server has the tool cached but is currently disconnected,
+  // spin it up just-in-time before executing the tool.
+  if (!server.connected) {
+    logMcpRenderer("info", `Lazy connecting to server ${server.name} for tool ${toolName}...`, {
+      operation: "lazyConnect",
+      serverId: server.id,
+      toolName
+    });
+    try {
+      await connectServer(server.id);
+      // Let the connection settle briefly just in case the server needs a moment to be ready
+      await new Promise(resolve => setTimeout(resolve, 500));
+    } catch (err) {
+      return {
+        result: null,
+        error: `Failed to lazy-connect to server ${server.name}: ${err instanceof Error ? err.message : String(err)}`
+      };
+    }
+  }
+
+  // Reset idle timer for this server since it's actively being used
+  resetMcpIdleTimer(server.id, server.name);
+
   let lastError: string | undefined;
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -281,7 +327,10 @@ export async function executeToolCall(
 
       // Success!
       const duration = Date.now() - startTime;
-      const resultSize = JSON.stringify(result.result).length;
+      // Avoid JSON.stringify just for logging — use cheap length estimate
+      const resultSize = typeof result.result === 'string'
+        ? result.result.length
+        : (result.result ? '~object' : 0);
 
       logMcpRenderer("info", "Tool call completed successfully", {
         operation: "executeToolCall",

--- a/src/renderer/src/stores/chatStore.ts
+++ b/src/renderer/src/stores/chatStore.ts
@@ -449,7 +449,34 @@ export const useChatStore = create<ChatState>()(
             // are now derived from _processingSessions (a Map). Old persisted state with the
             // flat fields is incompatible and would hydrate incorrectly.
             name: 'ai-worker-chat-v3',
-            storage: createJSONStorage(() => localStorage),
+            // ── Debounced storage adapter ──────────────────────────────────────
+            // WHY: During agent tool loops, addMessage/updateMessage fire rapidly
+            // (every tool call). Each triggers JSON.stringify + localStorage.setItem
+            // of ALL sessions, blocking the main thread. This adapter coalesces
+            // writes to at most once per second.
+            storage: (() => {
+                const base = createJSONStorage(() => localStorage)
+                let pendingTimer: ReturnType<typeof setTimeout> | null = null
+                let pendingValue: any = null
+                const DEBOUNCE_MS = 1000
+
+                return {
+                    getItem: (name: string) => base!.getItem(name),
+                    removeItem: (name: string) => base!.removeItem(name),
+                    setItem: (name: string, value: any) => {
+                        pendingValue = value
+                        if (pendingTimer === null) {
+                            pendingTimer = setTimeout(() => {
+                                if (pendingValue !== null) {
+                                    base!.setItem(name, pendingValue)
+                                    pendingValue = null
+                                }
+                                pendingTimer = null
+                            }, DEBOUNCE_MS)
+                        }
+                    },
+                }
+            })(),
             partialize: (state) => ({
                 sessions: state.sessions,
                 activeSessionId: state.activeSessionId,

--- a/src/renderer/src/stores/mcpStore.ts
+++ b/src/renderer/src/stores/mcpStore.ts
@@ -138,9 +138,9 @@ export const useMcpStore = create<McpState>()((set, get) => ({
 
                     return {
                         ...updated,
-                        // Reset runtime state
+                        // Reset runtime state but KEEP cached tools for lazy-connect
                         connected: false,
-                        tools: [],
+                        tools: updated.tools || [],
                         error: undefined
                     } as MCPServer;
                 });
@@ -180,8 +180,9 @@ export const useMcpStore = create<McpState>()((set, get) => ({
 
             set({ servers: initialServers, initialized: true })
 
-            // Auto-connect
-            const autoConnectServers = initialServers.filter(s => s.autoConnect)
+            // Lazy connect: Only auto-connect on startup if we don't have cached tool schemas.
+            // This prevents spawning expensive Node/Python child processes for unused servers.
+            const autoConnectServers = initialServers.filter(s => s.autoConnect && s.tools.length === 0)
             for (const server of autoConnectServers) {
                 // Connect sequentially to avoid overwhelming
                 get().connectServer(server.id).catch(console.error)
@@ -343,7 +344,8 @@ export const useMcpStore = create<McpState>()((set, get) => ({
             await electron.mcp.disconnect(id)
             set(state => ({
                 servers: state.servers.map(s =>
-                    s.id === id ? { ...s, connected: false, tools: [] } : s
+                    // Keep tools cached for lazy load later
+                    s.id === id ? { ...s, connected: false } : s
                 )
             }))
         } catch (error) {
@@ -450,26 +452,26 @@ export const useMcpStore = create<McpState>()((set, get) => ({
     getAllTools: () => {
         const toolMap: Map<string, MCPTool> = new Map();
         get().servers.forEach((server) => {
-            if (server.connected) {
-                server.tools.forEach(tool => {
-                    const existing = toolMap.get(tool.name);
+            // No longer require `server.connected` -> we serve cached tools for lazy-connect
+            server.tools.forEach(tool => {
+                const existing = toolMap.get(tool.name);
 
-                    // If we don't have this tool yet, or if the new one has a richer schema, take it
-                    const newScore = Object.keys(tool.inputSchema?.properties || {}).length;
-                    const existingScore = existing ? Object.keys(existing.inputSchema?.properties || {}).length : -1;
+                // If we don't have this tool yet, or if the new one has a richer schema, take it
+                const newScore = Object.keys(tool.inputSchema?.properties || {}).length;
+                const existingScore = existing ? Object.keys(existing.inputSchema?.properties || {}).length : -1;
 
-                    if (!existing || newScore > existingScore) {
-                        toolMap.set(tool.name, tool);
-                    }
-                });
-            }
+                if (!existing || newScore > existingScore) {
+                    toolMap.set(tool.name, tool);
+                }
+            });
         });
         return Array.from(toolMap.values());
     },
 
     findServerForTool: (toolName) => {
+        // Return server if it has the tool cached, regardless of connected state
         return get().servers.find(s =>
-            s.connected && s.tools.some(t => t.name === toolName)
+            s.tools.some(t => t.name === toolName)
         ) || null
     }
 }))

--- a/tests/e2e_ui_mocked.cjs
+++ b/tests/e2e_ui_mocked.cjs
@@ -49,6 +49,7 @@ const SCREENSHOT_DIR = path.join(__dirname, 'screenshots');
 
     try {
         const window = await electronApp.firstWindow();
+        await window.setViewportSize({ width: 1280, height: 900 });
         window.on('console', msg => console.log(`[Renderer]: ${msg.text()}`));
 
         // Mocking at the window level is more reliable than network interception for localhost in Electron
@@ -417,8 +418,6 @@ const SCREENSHOT_DIR = path.join(__dirname, 'screenshots');
 
         const chatInput = window.locator('[data-testid="chat-textarea"]');
         await chatInput.waitFor({ state: 'attached' });
-
-        await window.setViewportSize({ width: 1280, height: 900 });
 
         // Helper to send message
         const sendMessage = async (text) => {

--- a/tests/integration_test.cjs
+++ b/tests/integration_test.cjs
@@ -56,6 +56,7 @@ const SCREENSHOT_DIR = path.join(__dirname, 'screenshots');
 
     try {
         const window = await electronApp.firstWindow();
+        await window.setViewportSize({ width: 1280, height: 800 });
 
         window.on('console', msg => console.log(`[Renderer]: ${msg.text()}`));
         window.on('pageerror', err => console.error(`[Renderer Error]: ${err}`));


### PR DESCRIPTION
# Description

This PR refactors the Playwright browser tools to make them self-describing, significantly improving the maintainability, scalability, and robustness of the tool registry.

### Why this is needed
Previously, `PlaywrightService.ts` maintained a massive, hardcoded array of all tool schemas. This created several issues:
1. **Poor Separation of Concerns**: Tool schemas were decoupled from their actual class implementations. Modifying a tool meant changing two different places.
2. **Bloat**: As the agent's browser capabilities grew, `PlaywrightService.ts` became increasingly difficult to read and manage.
3. **Rigid Naming**: If an LLM hallucinated a tool name (e.g., trying to call `browser_click` instead of `click`), mapping and recovering from those errors required messy centralized logic.

### How this PR fixes it
- **Self-Describing Tools**: Every tool now extends `PlaywrightTool` and implements a mandatory `getSchema()` method. A tool class now completely owns its execution logic *and* its JSON schema side-by-side.
- **Dynamic Registry**: `PlaywrightService.ts` now automatically collects schemas by iterating through instantiated tool instances, keeping the service clean and declarative.
- **Alias Support**: Tools can now declare an `aliases` array (e.g., `navigate` declares `browser_navigate`). The service automatically publishes identical schemas under these alternative names, allowing the LLM to successfully execute tools even if it uses a common hallucinated name.

### Comparison with Industry Standards
This architectural pattern aligns our codebase with how state-of-the-art AI frameworks manage tools:
- **LangChain / LlamaIndex**: Tools extend a `BaseTool` class, co-locating the tool's `name`, `description`, and `args_schema` (Pydantic model) directly with the `_run` logic.
- **Model Context Protocol (MCP)**: MCP servers define capabilities by bundling the execution handler with the JSON Schema description so the server can dynamically serve the `tools/list` endpoint.
- **OpenAI / Vercel AI SDK**: Tools are defined as objects that encapsulate their `description`, `parameters` (via Zod), and the `execute` function in one cohesive unit.

By adopting this pattern, our tool abstractions are safer against configuration drift, and adding new browser capabilities is now as simple as dropping a new class into the `tools/` folder.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improves code structure without changing external functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Manual Test - Verified that all tool schemas are still correctly generated and exposed to the LLM, and that aliased tool names resolve to their implementations properly.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules