### PR TITLE
feat(ui): complete design system overhaul with Apple-style tokens

### DIFF
--- a/src/main/services/playwright/BrowserManager.ts
+++ b/src/main/services/playwright/BrowserManager.ts
@@ -50,6 +50,8 @@ export class BrowserManager {
     private store: Store<Record<string, unknown>>;
     /** Ensures concurrent callTool calls don't trigger multiple browser launches */
     private initializationPromise: Promise<void> | null = null;
+    /** Ensures concurrent background_scrape calls don't trigger multiple headless launches */
+    private initializationPromiseHeadless: Promise<void> | null = null;
 
     private headlessBrowser: Browser | null = null;
     private headlessContext: BrowserContext | null = null;
@@ -113,7 +115,10 @@ export class BrowserManager {
         // Serialize concurrent ensureBrowser() calls behind a single promise
         if (this.initializationPromise) {
             await this.initializationPromise;
-            return this.context!;
+            if (!this.context) {
+                throw new Error('[BrowserManager] Browser initialization finished but context is still null (likely closed during launch).');
+            }
+            return this.context;
         }
 
         this.initializationPromise = (async () => {
@@ -133,7 +138,7 @@ export class BrowserManager {
                 // Default blockAds to TRUE — matches the original PlaywrightService default
                 const blockAds = settings.blockAds !== undefined ? settings.blockAds : true;
 
-                console.log(`[BrowserManager] OS: ${process.platform}, target browser: ${browserType}`);
+                console.log(`[BrowserManager] OS: ${process.platform}, target browser: ${browserType}, headless: ${headless}`);
 
                 // Full set of stealth + stability args — restored from original PlaywrightService
                 const launchArgs = [
@@ -234,13 +239,17 @@ export class BrowserManager {
                 throw lastError || new Error('[BrowserManager] All browser launch attempts failed.');
             } catch (error) {
                 console.error('[BrowserManager] Failed to launch browser:', error);
-                this.initializationPromise = null; // Allow retry on next call
                 throw error;
+            } finally {
+                this.initializationPromise = null; // Clean up promise after completion/failure
             }
         })();
 
         await this.initializationPromise;
-        return this.context!;
+        if (!this.context) {
+            throw new Error('[BrowserManager] Browser initialization failed to produce a context.');
+        }
+        return this.context;
     }
 
     /**
@@ -316,61 +325,86 @@ export class BrowserManager {
     }
 
     private async ensureHeadlessPage(): Promise<Page> {
-        if (!this.headlessBrowser) {
-            console.log('[BrowserManager] Launching invisible headless browser with stealth...');
-            this.headlessBrowser = await stealthChromium.launch({
-                headless: true, // Use boolean for modern playwright compat
-                channel: 'chrome', // Use local chrome path
-                args: [
-                    '--headless=new', // Explicitly force the new headless mode to prevent stealth plugin from overriding it
-                    '--disable-blink-features=AutomationControlled',
-                    '--no-sandbox',
-                    '--disable-setuid-sandbox',
-                    '--disable-infobars',
-                    '--ignore-certificate-errors',
-                    '--disable-accelerated-2d-canvas',
-                    '--disable-gpu',
-                    '--disable-dev-shm-usage',
-                    '--window-size=1920,1080',
-                    '--disable-software-rasterizer'
-                ]
-            });
+        if (this.headlessPage && !this.headlessPage.isClosed()) return this.headlessPage;
+
+        // Serialize concurrent ensureHeadlessPage() calls behind a single promise
+        if (this.initializationPromiseHeadless) {
+            await this.initializationPromiseHeadless;
+            if (!this.headlessPage || this.headlessPage.isClosed()) {
+                throw new Error('[BrowserManager] Headless initialization finished but page is null or closed.');
+            }
+            return this.headlessPage;
         }
-        if (!this.headlessContext) {
-            this.headlessContext = await this.headlessBrowser!.newContext({
-                viewport: { width: 1920, height: 1080 },
-                locale: 'en-US',
-                timezoneId: 'America/New_York',
-                userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-                colorScheme: 'dark',
-                deviceScaleFactor: 2,
-                hasTouch: false,
-                isMobile: false
-            });
 
-            // Inject stealth init scripts to bypass further detection
-            await this.headlessContext.addInitScript(() => {
-                // Remove webdriver property
-                Object.defineProperty(navigator, 'webdriver', {
-                    get: () => undefined,
-                });
+        this.initializationPromiseHeadless = (async () => {
+            try {
+                if (!this.headlessBrowser) {
+                    console.log('[BrowserManager] Launching invisible headless browser with stealth...');
+                    this.headlessBrowser = await stealthChromium.launch({
+                        headless: true, // Use boolean for modern playwright compat
+                        channel: 'chrome', // Use local chrome path
+                        args: [
+                            '--headless=new', // Explicitly force the new headless mode to prevent stealth plugin from overriding it
+                            '--disable-blink-features=AutomationControlled',
+                            '--no-sandbox',
+                            '--disable-setuid-sandbox',
+                            '--disable-infobars',
+                            '--ignore-certificate-errors',
+                            '--disable-accelerated-2d-canvas',
+                            '--disable-gpu',
+                            '--disable-dev-shm-usage',
+                            '--window-size=1920,1080',
+                            '--disable-software-rasterizer'
+                        ]
+                    });
+                }
+                if (!this.headlessContext) {
+                    this.headlessContext = await this.headlessBrowser!.newContext({
+                        viewport: { width: 1920, height: 1080 },
+                        locale: 'en-US',
+                        timezoneId: 'America/New_York',
+                        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+                        colorScheme: 'dark',
+                        deviceScaleFactor: 2,
+                        hasTouch: false,
+                        isMobile: false
+                    });
 
-                // Mock languages
-                Object.defineProperty(navigator, 'languages', {
-                    get: () => ['en-US', 'en'],
-                });
+                    // Inject stealth init scripts to bypass further detection
+                    await this.headlessContext.addInitScript(() => {
+                        // Remove webdriver property
+                        Object.defineProperty(navigator, 'webdriver', {
+                            get: () => undefined,
+                        });
 
-                // Mock hardware properties
-                Object.defineProperty(navigator, 'hardwareConcurrency', {
-                    get: () => 8,
-                });
-                Object.defineProperty(navigator, 'deviceMemory', {
-                    get: () => 8,
-                });
-            });
-        }
+                        // Mock languages
+                        Object.defineProperty(navigator, 'languages', {
+                            get: () => ['en-US', 'en'],
+                        });
+
+                        // Mock hardware properties
+                        Object.defineProperty(navigator, 'hardwareConcurrency', {
+                            get: () => 8,
+                        });
+                        Object.defineProperty(navigator, 'deviceMemory', {
+                            get: () => 8,
+                        });
+                    });
+                }
+                if (!this.headlessPage || this.headlessPage.isClosed()) {
+                    this.headlessPage = await this.headlessContext!.newPage();
+                }
+            } catch (error) {
+                console.error('[BrowserManager] Failed to launch headless browser:', error);
+                throw error;
+            } finally {
+                this.initializationPromiseHeadless = null;
+            }
+        })();
+
+        await this.initializationPromiseHeadless;
         if (!this.headlessPage || this.headlessPage.isClosed()) {
-            this.headlessPage = await this.headlessContext!.newPage();
+            throw new Error('[BrowserManager] Headless initialization failed to produce an active page.');
         }
         return this.headlessPage;
     }
@@ -401,11 +435,14 @@ export class BrowserManager {
         }
 
         if (!this.page || this.page.isClosed()) {
-            const pages = this.context!.pages().filter(p => !p.isClosed());
+            if (!this.context) {
+                throw new Error('[BrowserManager] Cannot get page: Context is null after ensureBrowser.');
+            }
+            const pages = this.context.pages().filter(p => !p.isClosed());
             if (pages.length > 0) {
                 this.page = pages[pages.length - 1];
             } else {
-                this.page = await this.context!.newPage();
+                this.page = await this.context.newPage();
                 this.registerPage(this.page);
             }
         }
@@ -438,14 +475,18 @@ export class BrowserManager {
             this.idleTimer = null;
         }
 
+        // Reset promises to ensure subsequent calls don't await stale ones
+        this.initializationPromise = null;
+        this.initializationPromiseHeadless = null;
+
         if (this.context) {
-            await this.context.close();
+            await this.context.close().catch(e => console.error('[BrowserManager] Error closing context:', e));
             this.context = null;
             this.page = null;
             this.pagesMap.clear();
         }
         if (this.headlessBrowser) {
-            await this.headlessBrowser.close();
+            await this.headlessBrowser.close().catch(e => console.error('[BrowserManager] Error closing headless browser:', e));
             this.headlessBrowser = null;
             this.headlessContext = null;
             this.headlessPage = null;

--- a/src/renderer/src/components/AuthModal.tsx
+++ b/src/renderer/src/components/AuthModal.tsx
@@ -89,7 +89,7 @@ export function AuthModal({ isOpen, onClose }: AuthModalProps) {
                         >
                             <X size={20} />
                         </button>
-                        <h2 className="text-2xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-[var(--color-text-primary)] to-[var(--color-text-muted)]">
+                        <h2 className="text-2xl font-bold text-[var(--color-text-primary)]">
                             {mode === 'signin' ? 'Welcome Back' : 'Create Account'}
                         </h2>
                         <p className="text-sm text-[var(--color-text-muted)] mt-1">

--- a/src/renderer/src/components/Header.tsx
+++ b/src/renderer/src/components/Header.tsx
@@ -23,7 +23,7 @@ export function Header({ status }: HeaderProps) {
                         {user ? (
                             <div className="flex items-center gap-3">
                                 <div className="flex items-center gap-2 text-[var(--text-sm)] text-[var(--color-text-primary)]">
-                                    <div className="w-6 h-6 rounded-full bg-gradient-to-tr from-[var(--color-brand-teal)] to-[var(--color-primary)] flex items-center justify-center text-[10px] font-[var(--font-weight-bold)] text-white uppercase">
+                                    <div className="w-6 h-6 rounded-full bg-gradient-to-tr from-[var(--color-brand-teal)] to-[var(--color-primary)] flex items-center justify-center text-[10px] font-[var(--font-weight-bold)] text-[var(--color-text-inverse)] uppercase">
                                         {user.displayName ? user.displayName[0] : user.email?.[0] || 'U'}
                                     </div>
                                     <span className="hidden sm:inline">{user.displayName || user.email?.split('@')[0]}</span>

--- a/src/renderer/src/components/Header.tsx
+++ b/src/renderer/src/components/Header.tsx
@@ -3,6 +3,8 @@ import { Wifi, WifiOff, User as UserIcon, LogOut } from 'lucide-react'
 import { useAuthStore } from '../stores/authStore'
 import { AuthModal } from './AuthModal'
 import { FEATURE_FLAGS } from '../lib/constants'
+import { Button } from './primitives/Button'
+import { StatusDot } from './primitives/StatusDot'
 
 interface HeaderProps {
     status: { provider: string | null; available: boolean }
@@ -13,35 +15,39 @@ export function Header({ status }: HeaderProps) {
     const { user, signOut } = useAuthStore()
 
     return (
-        <header className="h-12 flex items-center justify-between px-4 border-b border-[var(--color-border)] flex-shrink-0">
+        <header className="h-[var(--space-12)] flex items-center justify-between px-[var(--space-4)] border-b border-[var(--color-border)] flex-shrink-0">
             <div className="flex items-center gap-4">
                 {/* User Auth Section */}
                 {FEATURE_FLAGS.AUTH_ENABLED && (
                     <>
                         {user ? (
                             <div className="flex items-center gap-3">
-                                <div className="flex items-center gap-2 text-sm text-[var(--color-text-primary)]">
-                                    <div className="w-6 h-6 rounded-full bg-gradient-to-tr from-[var(--color-brand-teal)] to-blue-500 flex items-center justify-center text-[10px] font-bold text-white uppercase">
+                                <div className="flex items-center gap-2 text-[var(--text-sm)] text-[var(--color-text-primary)]">
+                                    <div className="w-6 h-6 rounded-full bg-gradient-to-tr from-[var(--color-brand-teal)] to-[var(--color-primary)] flex items-center justify-center text-[10px] font-[var(--font-weight-bold)] text-white uppercase">
                                         {user.displayName ? user.displayName[0] : user.email?.[0] || 'U'}
                                     </div>
                                     <span className="hidden sm:inline">{user.displayName || user.email?.split('@')[0]}</span>
                                 </div>
-                                <button
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
                                     onClick={() => signOut()}
-                                    className="p-1.5 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface)] rounded-lg transition-colors"
+                                    className="p-1.5 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
                                     title="Sign Out"
                                 >
                                     <LogOut size={14} />
-                                </button>
+                                </Button>
                             </div>
                         ) : (
-                            <button
+                            <Button
+                                variant="ghost"
+                                size="sm"
                                 onClick={() => setIsAuthModalOpen(true)}
-                                className="flex items-center gap-2 px-3 py-1.5 bg-[var(--color-brand-teal)]/10 text-[var(--color-brand-teal)] rounded-lg text-xs font-medium hover:bg-[var(--color-brand-teal)]/20 transition-colors"
+                                className="text-[var(--color-brand-teal)] hover:bg-[var(--color-brand-teal)]/10"
                             >
                                 <UserIcon size={14} />
                                 <span>Sign In</span>
-                            </button>
+                            </Button>
                         )}
                         <AuthModal isOpen={isAuthModalOpen} onClose={() => setIsAuthModalOpen(false)} />
                     </>
@@ -49,12 +55,12 @@ export function Header({ status }: HeaderProps) {
             </div>
 
             <div className="text-[10px] uppercase tracking-widest text-[var(--color-text-dim)] hidden sm:flex items-center gap-2">
-                <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-success)] animate-pulse" />
+                <StatusDot variant="success" size="sm" animated />
                 local-session: active
             </div>
 
             {/* LLM Status */}
-            <div className={`flex items-center gap-1.5 text-[10px] font-medium ${status.available ? 'text-[var(--color-success)]' : 'text-[var(--color-warning)]'
+            <div className={`flex items-center gap-1.5 text-[10px] font-[var(--font-weight-medium)] ${status.available ? 'text-[var(--color-success)]' : 'text-[var(--color-warning)]'
                 }`}>
                 {status.available ? <Wifi size={12} /> : <WifiOff size={12} />}
                 <span className="uppercase tracking-wide">

--- a/src/renderer/src/components/JumpToBottom.tsx
+++ b/src/renderer/src/components/JumpToBottom.tsx
@@ -29,7 +29,7 @@ export function JumpToBottom({ isAtBottom, hasUnread, onScrollToBottom }: JumpTo
         >
           <button
             onClick={onScrollToBottom}
-            className="flex items-center gap-2 px-4 py-2 bg-[var(--color-brand-teal)] hover:bg-[var(--color-brand-teal)]/90 text-white rounded-full shadow-lg shadow-black/20 text-sm font-medium transition-all hover:scale-105"
+            className="flex items-center gap-2 px-4 py-2 bg-[var(--color-brand-teal)] hover:bg-[var(--color-brand-teal)]/90 text-[var(--color-text-inverse)] rounded-full shadow-lg text-sm font-medium transition-all hover:scale-105"
           >
             <ArrowDown size={16} />
             New messages
@@ -45,7 +45,7 @@ export function JumpToBottom({ isAtBottom, hasUnread, onScrollToBottom }: JumpTo
         >
           <button
             onClick={onScrollToBottom}
-            className="flex items-center gap-2 p-2 bg-[var(--color-card-elevated)] border border-[var(--color-border)] hover:bg-[var(--color-surface)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] rounded-full shadow-lg shadow-black/20 transition-all"
+            className="flex items-center gap-2 p-2 bg-[var(--color-card-elevated)] border border-[var(--color-border)] hover:bg-[var(--color-surface)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] rounded-full shadow-lg transition-all"
           >
             <ArrowDown size={16} />
           </button>

--- a/src/renderer/src/components/MissingDependenciesScreen.tsx
+++ b/src/renderer/src/components/MissingDependenciesScreen.tsx
@@ -69,8 +69,8 @@ export function MissingDependenciesScreen({ onResolved }: { onResolved: () => vo
 
     if (loading && missing.length === 0) {
         return (
-            <div className="flex items-center justify-center p-8 bg-[#0f1115] text-white w-full h-full">
-                <div className="animate-pulse">Checking system dependencies...</div>
+            <div className="flex items-center justify-center p-8 bg-[var(--color-bg-dark)] text-[var(--color-text-primary)] w-full h-full">
+                <div className="text-[var(--color-text-muted)]">Checking system dependencies...</div>
             </div>
         );
     }
@@ -80,8 +80,8 @@ export function MissingDependenciesScreen({ onResolved }: { onResolved: () => vo
     }
 
     return (
-        <div className="fixed inset-0 z-50 bg-[#0f1115] flex items-center justify-center text-white p-8 overflow-y-auto">
-            <div className="max-w-md w-full p-8 rounded-xl border border-white/10 bg-[#16181d] shadow-2xl space-y-6">
+        <div className="fixed inset-0 z-50 bg-[var(--color-bg-dark)] flex items-center justify-center text-[var(--color-text-primary)] p-8 overflow-y-auto">
+            <div className="max-w-md w-full p-8 rounded-[var(--radius-xl)] border border-[var(--color-border)] bg-[var(--color-card-dark)] shadow-[var(--shadow-xl)] space-y-6">
                 <div className="space-y-2">
                     <h2 className="text-2xl font-bold">Missing Dependencies</h2>
                     <p className="text-sm text-gray-400">

--- a/src/renderer/src/components/SettingsPanel.tsx
+++ b/src/renderer/src/components/SettingsPanel.tsx
@@ -121,7 +121,7 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
                 <SidebarHeader />
 
                 <div className="flex-1 overflow-y-auto px-5 py-4">
-                    <h3 className="text-[10px] font-bold text-white/40 tracking-wider uppercase mb-3">
+                    <h3 className="text-[10px] font-[var(--font-weight-bold)] text-[var(--color-text-dim)] tracking-wider uppercase mb-3">
                         Settings
                     </h3>
                     <nav className="flex flex-col gap-1">
@@ -304,7 +304,7 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
                                             key={theme}
                                             onClick={() => settings.setTheme(theme)}
                                             className={`flex-1 py-2 px-4 rounded-lg text-sm capitalize transition-colors ${settings.theme === theme
-                                                ? 'bg-[var(--color-brand-teal)] text-white'
+                                                ? 'bg-[var(--color-brand-teal)] text-[var(--color-text-inverse)]'
                                                 : 'bg-[var(--color-surface)] text-[var(--color-text-secondary)] hover:bg-[var(--color-border)]'
                                                 }`}
                                         >
@@ -373,7 +373,7 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
 
                             <Card variant="glass" padding="lg" className="text-center">
                                 <div className="w-20 h-20 bg-gradient-to-br from-[var(--color-primary)] to-[var(--color-accent)] rounded-[var(--radius-xl)] flex items-center justify-center mx-auto mb-[var(--space-4)] shadow-lg">
-                                    <Sparkles className="w-10 h-10 text-white" />
+                                    <Sparkles className="w-10 h-10 text-[var(--color-text-inverse)]" />
                                 </div>
                                 <h4 className="text-[var(--text-2xl)] font-[var(--font-weight-bold)] text-[var(--color-text-primary)]">{APP_INFO.NAME}</h4>
                                 <p className="text-[var(--text-sm)] text-[var(--color-text-muted)] mt-[var(--space-1)]">Version {APP_INFO.VERSION}</p>

--- a/src/renderer/src/components/SettingsPanel.tsx
+++ b/src/renderer/src/components/SettingsPanel.tsx
@@ -19,7 +19,11 @@ import {
     Globe,
     FolderOpen,
     FileText,
-    Mic
+    Mic,
+    Sparkles,
+    Activity,
+    Clock,
+    Zap
 } from 'lucide-react'
 import { useLogStore } from '../stores/logStore'
 import { useSettingsStore, Theme, LLMProviderType } from '../stores/settingsStore'
@@ -28,6 +32,8 @@ import { FEATURE_FLAGS, APP_INFO, VOICE_CONFIG } from '../lib/constants'
 import { isDevelopmentMode } from '../lib/featureFlags'
 import { EnhancedFeatureFlagsPanel } from './EnhancedFeatureFlagsPanel'
 import { SystemDependenciesSettings } from './SystemDependenciesSettings'
+import { Card, CardContent } from './primitives/Card'
+import { StatusBadge } from './primitives/StatusDot'
 import { AccountSettings } from './settings/AccountSettings'
 import {
     chat,
@@ -363,24 +369,61 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
                 {
                     activeSection === 'about' && (
                         <div className="space-y-6">
-                            <h3 className="text-xl font-bold text-[var(--color-text-primary)]">About</h3>
+                            <h3 className="text-[var(--text-xl)] font-[var(--font-weight-bold)] text-[var(--color-text-primary)]">About</h3>
 
-                            <div className="bg-[var(--color-card-elevated)] border border-[var(--color-border)] rounded-xl p-6 text-center">
-                                <div className="w-16 h-16 bg-[#00a896] rounded-2xl flex items-center justify-center mx-auto mb-4">
-                                    <div className="w-8 h-8 border-2 border-white rounded-lg flex items-center justify-center">
-                                        <div className="w-4 h-[2px] bg-white rounded-full"></div>
-                                    </div>
+                            <Card variant="glass" padding="lg" className="text-center">
+                                <div className="w-20 h-20 bg-gradient-to-br from-[var(--color-primary)] to-[var(--color-accent)] rounded-[var(--radius-xl)] flex items-center justify-center mx-auto mb-[var(--space-4)] shadow-lg">
+                                    <Sparkles className="w-10 h-10 text-white" />
                                 </div>
-                                <h4 className="text-xl font-bold text-[var(--color-text-primary)]">{APP_INFO.NAME}</h4>
-                                <p className="text-[var(--color-text-dim)] text-sm">Version {APP_INFO.VERSION}</p>
-                                <p className="text-[var(--color-text-secondary)] mt-4 text-sm">
-                                    Voice-first desktop workspace with MCP integration
+                                <h4 className="text-[var(--text-2xl)] font-[var(--font-weight-bold)] text-[var(--color-text-primary)]">{APP_INFO.NAME}</h4>
+                                <p className="text-[var(--text-sm)] text-[var(--color-text-muted)] mt-[var(--space-1)]">Version {APP_INFO.VERSION}</p>
+                                <p className="text-[var(--text-sm)] text-[var(--color-text-secondary)] mt-[var(--space-4)] max-w-sm mx-auto">
+                                    Voice-first desktop workspace with MCP integration. Built for AI-assisted productivity.
                                 </p>
-                                <div className="mt-6 pt-4 border-t border-[var(--color-border)]">
-                                    <p className="text-xs text-[var(--color-text-dim)]">
-                                        Built with Electron, React, and ❤️
+                                <div className="mt-[var(--space-6)] pt-[var(--space-4)] border-t border-[var(--color-border)]">
+                                    <p className="text-[var(--text-xs)] text-[var(--color-text-dim)]">
+                                        Built with Electron, React, and TypeScript
                                     </p>
                                 </div>
+                            </Card>
+
+                            <div className="grid grid-cols-2 gap-[var(--space-3)]">
+                                <Card variant="default" padding="md" className="flex items-center gap-3">
+                                    <div className="w-10 h-10 rounded-[var(--radius-md)] bg-[var(--color-success)]/15 flex items-center justify-center">
+                                        <Activity className="w-5 h-5 text-[var(--color-success)]" />
+                                    </div>
+                                    <div>
+                                        <p className="text-[var(--text-xs)] text-[var(--color-text-dim)]">Status</p>
+                                        <StatusBadge variant="success" label="Active" animated />
+                                    </div>
+                                </Card>
+                                <Card variant="default" padding="md" className="flex items-center gap-3">
+                                    <div className="w-10 h-10 rounded-[var(--radius-md)] bg-[var(--color-primary)]/15 flex items-center justify-center">
+                                        <Zap className="w-5 h-5 text-[var(--color-primary)]" />
+                                    </div>
+                                    <div>
+                                        <p className="text-[var(--text-xs)] text-[var(--color-text-dim)]">Platform</p>
+                                        <p className="text-[var(--text-sm)] font-[var(--font-weight-medium)] text-[var(--color-text-primary)]">Electron</p>
+                                    </div>
+                                </Card>
+                                <Card variant="default" padding="md" className="flex items-center gap-3">
+                                    <div className="w-10 h-10 rounded-[var(--radius-md)] bg-[var(--color-accent)]/15 flex items-center justify-center">
+                                        <Clock className="w-5 h-5 text-[var(--color-accent)]" />
+                                    </div>
+                                    <div>
+                                        <p className="text-[var(--text-xs)] text-[var(--color-text-dim)]">Launch</p>
+                                        <p className="text-[var(--text-sm)] font-[var(--font-weight-medium)] text-[var(--color-text-primary)]">Ready</p>
+                                    </div>
+                                </Card>
+                                <Card variant="default" padding="md" className="flex items-center gap-3">
+                                    <div className="w-10 h-10 rounded-[var(--radius-md)] bg-[var(--color-brand-teal)]/15 flex items-center justify-center">
+                                        <Cpu className="w-5 h-5 text-[var(--color-brand-teal)]" />
+                                    </div>
+                                    <div>
+                                        <p className="text-[var(--text-xs)] text-[var(--color-text-dim)]">Engine</p>
+                                        <p className="text-[var(--text-sm)] font-[var(--font-weight-medium)] text-[var(--color-text-primary)]">React</p>
+                                    </div>
+                                </Card>
                             </div>
 
                             <SystemDependenciesSettings />

--- a/src/renderer/src/components/SettingsPanel.tsx
+++ b/src/renderer/src/components/SettingsPanel.tsx
@@ -372,7 +372,7 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
                             <h3 className="text-[var(--text-xl)] font-[var(--font-weight-bold)] text-[var(--color-text-primary)]">About</h3>
 
                             <Card variant="glass" padding="lg" className="text-center">
-                                <div className="w-20 h-20 bg-gradient-to-br from-[var(--color-primary)] to-[var(--color-accent)] rounded-[var(--radius-xl)] flex items-center justify-center mx-auto mb-[var(--space-4)] shadow-lg">
+                                <div className="w-20 h-20 bg-[var(--color-primary)] rounded-[var(--radius-xl)] flex items-center justify-center mx-auto mb-[var(--space-4)] shadow-lg">
                                     <Sparkles className="w-10 h-10 text-[var(--color-text-inverse)]" />
                                 </div>
                                 <h4 className="text-[var(--text-2xl)] font-[var(--font-weight-bold)] text-[var(--color-text-primary)]">{APP_INFO.NAME}</h4>

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { SidebarHeader } from './sidebar/SidebarHeader'
-// import { ActiveAgentsList } from './sidebar/ActiveAgentsList'
 import { RecentSessionsList } from './sidebar/RecentSessionsList'
 import { SidebarFooter } from './sidebar/SidebarFooter'
 import { useChatStore } from '../stores/chatStore'
@@ -12,24 +11,18 @@ interface SidebarProps {
   onViewChange: (view: View) => void
 }
 
-/**
- * Unified Sidebar Orchestrator for the Co-Worker Hub.
- * Composes the header, active agents, recent sessions, and footer.
- */
 export function Sidebar({ currentView, onViewChange }: SidebarProps) {
   const { sidebarOpen } = useChatStore()
 
   if (!sidebarOpen) return null
 
   return (
-    <div className="w-64 flex-shrink-0 bg-[var(--color-card-dark)] hidden md:flex flex-col h-full border-r border-[var(--color-border)] transition-all duration-300">
+    <div className="w-64 flex-shrink-0 bg-[var(--color-card-dark)] hidden md:flex flex-col h-full border-r border-[var(--color-border)] transition-all duration-[var(--duration-normal)]">
       {/* 1. Header with Logo */}
       <SidebarHeader />
 
       {/* 2. Scrollable Body containing Agents & Sessions */}
       <div className="flex-1 overflow-y-auto flex flex-col">
-        {/* ActiveAgentsList removed as per user request to simplify sidebar */}
-
         {/* Divider */}
         <div className="mx-5 my-2 border-t border-[var(--color-border)]" />
 

--- a/src/renderer/src/components/WorkflowTiles.tsx
+++ b/src/renderer/src/components/WorkflowTiles.tsx
@@ -41,44 +41,44 @@ export function WorkflowTiles() {
     const templates = templatesData as WorkflowTemplate[]
 
     return (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-8 animate-in fade-in slide-in-from-bottom-4 duration-slow">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-[var(--space-4)] mt-8 animate-in fade-in slide-in-from-bottom-4 duration-[var(--duration-slow)]">
             {templates.map((template) => (
                 <button
                     key={template.id}
                     onClick={() => handleTileClick(template.prompt)}
                     className={`
-                        flex flex-col items-start text-left p-4 rounded-tile border 
+                        flex flex-col items-start text-left p-4 rounded-[var(--radius-tile)] border 
                         bg-[var(--color-surface)] border-[var(--color-border)]
                         hover:border-[var(--color-border-hover)] hover:bg-[var(--color-card-dark)]
-                        hover:shadow-glass 
-                        transition-all duration-slow group relative overflow-hidden
+                        hover:shadow-[var(--shadow-glass)] 
+                        transition-all duration-[var(--duration-slow)] group relative overflow-hidden
                     `}
                 >
                     {/* Glassmorphism Background Effect */}
-                    <div className="absolute inset-0 bg-gradient-to-br from-[var(--color-surface)] to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-slow" />
+                    <div className="absolute inset-0 bg-gradient-to-br from-[var(--color-surface)] to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-[var(--duration-slow)]" />
 
-                    <div className={`mb-3 p-2.5 rounded-xl bg-[var(--color-surface)] group-hover:bg-[var(--color-border)] transition-colors duration-slow`}>
-                        <div className={`${template.color.split(' ')[0]} group-hover:scale-110 transition-transform duration-slow`}>
+                    <div className={`mb-3 p-2.5 rounded-[var(--radius-xl)] bg-[var(--color-surface)] group-hover:bg-[var(--color-border)] transition-colors duration-[var(--duration-slow)]`}>
+                        <div className={`${template.color.split(' ')[0]} group-hover:scale-110 transition-transform duration-[var(--duration-slow)]`}>
                            {ICON_MAP[template.iconName] || <Zap size={18} />}
                         </div>
                     </div>
 
                     <div className="flex-1 w-full">
-                        <h3 className="font-bold text-sm text-[var(--color-text-primary)] mb-1.5 group-hover:translate-x-1 transition-transform duration-slow">
+                        <h3 className="font-[var(--font-weight-bold)] text-[var(--text-sm)] text-[var(--color-text-primary)] mb-1.5 group-hover:translate-x-1 transition-transform duration-[var(--duration-slow)]">
                             {template.title}
                         </h3>
-                        <p className="text-[11px] text-[var(--color-text-muted)] line-clamp-2 leading-relaxed group-hover:text-[var(--color-text-secondary)] transition-colors duration-slow">
+                        <p className="text-[11px] text-[var(--color-text-muted)] line-clamp-2 leading-[var(--leading-relaxed)] group-hover:text-[var(--color-text-secondary)] transition-colors duration-[var(--duration-slow)]">
                             {template.description}
                         </p>
                     </div>
 
                     {/* Subtle arrow indicator */}
-                    <div className="absolute top-5 right-5 opacity-0 group-hover:opacity-100 -translate-x-2 group-hover:translate-x-0 transition-all duration-slow">
+                    <div className="absolute top-5 right-5 opacity-0 group-hover:opacity-100 -translate-x-2 group-hover:translate-x-0 transition-all duration-[var(--duration-slow)]">
                         <ChevronRight size={14} className="text-[var(--color-text-muted)]" />
                     </div>
                     
                     {/* Bottom accent line */}
-                    <div className="absolute bottom-0 left-0 h-[2px] w-0 bg-[var(--color-primary)] group-hover:w-full transition-all duration-slow" />
+                    <div className="absolute bottom-0 left-0 h-[2px] w-0 bg-[var(--color-primary)] group-hover:w-full transition-all duration-[var(--duration-slow)]" />
                 </button>
             ))}
         </div>

--- a/src/renderer/src/components/chat/EmptyState.tsx
+++ b/src/renderer/src/components/chat/EmptyState.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { WorkflowTiles } from '../WorkflowTiles'
+import { StatusBadge } from '../primitives/StatusDot'
 
 /**
  * Co-Worker Hub Welcome Screen
@@ -9,23 +10,23 @@ export function EmptyState() {
     <div className="flex flex-col items-center justify-center min-h-full max-w-4xl mx-auto w-full pt-8 pb-32">
       
       {/* System Active Badge */}
-      <div className="mb-8 px-3 py-1 rounded-full border border-[var(--color-primary)]/30 bg-[var(--color-primary)]/10 text-[var(--color-primary)] text-[10px] font-bold tracking-widest uppercase">
-        System Active
+      <div className="mb-8">
+        <StatusBadge variant="active" label="System Active" animated />
       </div>
 
       {/* Greeting */}
       <div className="text-center mb-6">
-        <h1 className="text-4xl md:text-5xl font-bold tracking-tight text-[var(--color-text-primary)] mb-2">
+        <h1 className="text-[var(--text-4xl)] md:text-[var(--text-3xl)] font-[var(--font-weight-bold)] tracking-tight text-[var(--color-text-primary)] mb-2">
           Hey!
         </h1>
-        <h2 className="text-4xl md:text-5xl font-bold tracking-tight bg-clip-text text-transparent bg-[image:var(--gradient-text)]">
+        <h2 className="text-[var(--text-4xl)] md:text-[var(--text-3xl)] font-[var(--font-weight-bold)] tracking-tight text-[var(--color-text-primary)]">
           What's on your mind?
         </h2>
       </div>
 
       {/* Subtitle */}
-      <p className="text-[var(--color-text-secondary)] text-md text-center max-w-2xl mb-8">
-        Your Co-Worker is ready. Delegate tasks across connected systems right here or press <span className="font-mono bg-[var(--color-surface)] px-1 py-0.5 rounded text-[var(--color-text-primary)] text-sm">Cmd+K</span> to quickly search.
+      <p className="text-[var(--color-text-secondary)] text-[var(--text-base)] text-center max-w-2xl mb-8">
+        Your Co-Worker is ready. Delegate tasks across connected systems right here or press <span className="font-[var(--font-family-mono)] bg-[var(--color-surface)] px-1 py-0.5 rounded text-[var(--color-text-primary)] text-[var(--text-sm)]">Cmd+K</span> to quickly search.
       </p>
 
       {/* Agent Cards Grid */}

--- a/src/renderer/src/components/chat/MessageActions.tsx
+++ b/src/renderer/src/components/chat/MessageActions.tsx
@@ -41,7 +41,7 @@ export function MessageActions({ messageId, content, actions }: MessageActionsPr
               }}
               className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
                 action.type === 'continue'
-                  ? 'bg-[var(--color-accent)] hover:bg-[var(--color-accent)]/80 text-white'
+                  ? 'bg-[var(--color-accent)] hover:bg-[var(--color-accent)]/80 text-[var(--color-text-inverse)]'
                   : 'bg-[var(--color-surface-hover)] hover:bg-[var(--color-border)] border border-[var(--color-border)] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'
               }`}
             >

--- a/src/renderer/src/components/chat/MessageAvatar.tsx
+++ b/src/renderer/src/components/chat/MessageAvatar.tsx
@@ -16,9 +16,9 @@ export function MessageAvatar({ isUser }: MessageAvatarProps) {
     <Avatar
       icon={
         isUser ? (
-          <User size={18} className="text-white" />
+          <User size={18} className="text-[var(--color-text-inverse)]" />
         ) : (
-          <Bot size={18} className="text-white" />
+          <Bot size={18} className="text-[var(--color-text-inverse)]" />
         )
       }
       colorClass={

--- a/src/renderer/src/components/chat/MessageBubble.tsx
+++ b/src/renderer/src/components/chat/MessageBubble.tsx
@@ -99,7 +99,7 @@ export function MessageBubble({ message, onDelete, isLast = false }: MessageBubb
           className={cn(
             'rounded-[var(--radius-bubble)] px-[var(--space-bubble-px)] py-[var(--space-bubble-py)] shadow-[var(--shadow-sm)]',
             isUser
-              ? 'bg-[var(--color-primary)] text-white'
+              ? 'bg-[var(--color-primary)] text-[var(--color-text-inverse)]'
               : 'bg-[var(--color-card-dark)] border border-[var(--color-border)] text-[var(--color-text-primary)]'
           )}
         >

--- a/src/renderer/src/components/chat/MessageBubble.tsx
+++ b/src/renderer/src/components/chat/MessageBubble.tsx
@@ -1,16 +1,5 @@
 /**
  * MessageBubble.tsx — Slim orchestrator for chat message rendering.
- *
- * This component is now a composition of atomic sub-components:
- *   - MessageAvatar — user/bot avatar icon
- *   - MessageAttachments — file attachment cards
- *   - ThinkingBlock — collapsible LLM reasoning
- *   - MessageContent — cleaned markdown rendering
- *   - ToolCallList — grouped tool call checklist
- *   - MessageActions — copy, regenerate, action buttons
- *   - MessageTimestamp — formatted time display
- *
- * Each sub-component can be independently styled, tracked, and experimented on.
  */
 
 import React from 'react'
@@ -38,7 +27,6 @@ export function MessageBubble({ message, onDelete, isLast = false }: MessageBubb
   const isUser = message.role === 'user'
   const isSystem = message.role === 'system'
 
-  // Filter out internal tools from the standard checklist view
   const visibleToolCalls = message.toolCalls?.filter(
     tc =>
       tc.name !== 'create_execution_plan' &&
@@ -46,14 +34,13 @@ export function MessageBubble({ message, onDelete, isLast = false }: MessageBubb
       tc.name !== 'memory_update_entity'
   )
 
-  // Check for progress summary update (Legacy or Memory)
   const progressToolCall = message.toolCalls?.find(
     tc =>
       tc.name === 'update_progress_summary' ||
       tc.name === 'memory_update_entity'
   )
 
-  // SPECIAL CASE: If message is ONLY a progress update (no content, no other tools)
+  // Progress checkpoint only message
   if (
     !isUser &&
     !message.content &&
@@ -61,8 +48,8 @@ export function MessageBubble({ message, onDelete, isLast = false }: MessageBubb
     progressToolCall
   ) {
     return (
-      <div className="flex justify-center my-2 animate-pulse">
-        <div className="flex items-center gap-1.5 text-[var(--color-text-dim)] text-[10px] font-medium px-2 py-1 rounded-full bg-[var(--color-surface)]">
+      <div className="flex justify-center my-2">
+        <div className="flex items-center gap-1.5 text-[var(--color-text-dim)] text-[10px] font-[var(--font-weight-medium)] px-2 py-1 rounded-[var(--radius-pill)] bg-[var(--color-surface)]">
           <Save size={10} />
           <span>Saving progress checkpoint...</span>
         </div>
@@ -70,11 +57,11 @@ export function MessageBubble({ message, onDelete, isLast = false }: MessageBubb
     )
   }
 
-  // System message — minimal centered badge
+  // System message
   if (isSystem) {
     return (
       <div className="flex justify-center my-2">
-        <div className="bg-[var(--color-surface)] text-[var(--color-text-muted)] text-xs px-3 py-1 rounded-full">
+        <div className="bg-[var(--color-surface)] text-[var(--color-text-muted)] text-[var(--text-xs)] px-3 py-1 rounded-[var(--radius-pill)]">
           <FormattedText content={message.content} />
         </div>
       </div>
@@ -110,7 +97,7 @@ export function MessageBubble({ message, onDelete, isLast = false }: MessageBubb
         {/* 2. Main Message Bubble */}
         <div
           className={cn(
-            'rounded-[var(--radius-bubble)] px-[var(--space-bubble-px)] py-[var(--space-bubble-py)] shadow-sm',
+            'rounded-[var(--radius-bubble)] px-[var(--space-bubble-px)] py-[var(--space-bubble-py)] shadow-[var(--shadow-sm)]',
             isUser
               ? 'bg-[var(--color-primary)] text-white'
               : 'bg-[var(--color-card-dark)] border border-[var(--color-border)] text-[var(--color-text-primary)]'
@@ -127,7 +114,7 @@ export function MessageBubble({ message, onDelete, isLast = false }: MessageBubb
             progressToolCall &&
             (message.content ||
               (visibleToolCalls && visibleToolCalls.length > 0)) && (
-              <div className="flex items-center gap-1.5 text-[var(--color-text-muted)] text-[10px] font-medium mt-3 px-1 border-t border-[var(--color-border)] pt-2">
+              <div className="flex items-center gap-1.5 text-[var(--color-text-muted)] text-[10px] font-[var(--font-weight-medium)] mt-3 px-1 border-t border-[var(--color-border)] pt-2">
                 <Save size={10} />
                 <span>Progress checkpoint saved</span>
               </div>

--- a/src/renderer/src/components/chat/MessageTimestamp.tsx
+++ b/src/renderer/src/components/chat/MessageTimestamp.tsx
@@ -1,14 +1,8 @@
 interface MessageTimestampProps {
-  /** Unix timestamp in milliseconds */
   timestamp: number
-  /** Whether this is a user message (affects color) */
   isUser?: boolean
 }
 
-/**
- * Formatted message timestamp (e.g., "2:34 PM").
- * Extracted from MessageBubble for independent styling and experiment control.
- */
 export function MessageTimestamp({ timestamp, isUser = false }: MessageTimestampProps) {
   const formatted = new Date(timestamp).toLocaleTimeString([], {
     hour: '2-digit',
@@ -18,7 +12,7 @@ export function MessageTimestamp({ timestamp, isUser = false }: MessageTimestamp
   return (
     <p
       className={`text-[var(--font-size-meta)] mt-1 ${
-        isUser ? 'text-white/60' : 'text-white/30'
+        isUser ? 'text-white/60' : 'text-[var(--color-text-dim)]'
       }`}
     >
       {formatted}

--- a/src/renderer/src/components/chat/MessageTimestamp.tsx
+++ b/src/renderer/src/components/chat/MessageTimestamp.tsx
@@ -12,7 +12,7 @@ export function MessageTimestamp({ timestamp, isUser = false }: MessageTimestamp
   return (
     <p
       className={`text-[var(--font-size-meta)] mt-1 ${
-        isUser ? 'text-white/60' : 'text-[var(--color-text-dim)]'
+        isUser ? 'text-[var(--color-text-inverse-muted)]' : 'text-[var(--color-text-dim)]'
       }`}
     >
       {formatted}

--- a/src/renderer/src/components/chat/ProgressBanner.tsx
+++ b/src/renderer/src/components/chat/ProgressBanner.tsx
@@ -54,7 +54,7 @@ export function ProgressBanner({ session }: ProgressBannerProps) {
             <motion.div
               initial={{ width: 0 }}
               animate={{ width: `${session.progress}%` }}
-              className="h-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-primary)] relative"
+              className="h-full bg-[var(--color-brand-teal)] relative"
             >
               <div className="absolute inset-0 bg-white/20" />
             </motion.div>

--- a/src/renderer/src/components/chat/ProgressBanner.tsx
+++ b/src/renderer/src/components/chat/ProgressBanner.tsx
@@ -50,13 +50,13 @@ export function ProgressBanner({ session }: ProgressBannerProps) {
             </span>
             <span>{session.progress}%</span>
           </div>
-          <div className="h-1.5 w-full bg-white/5 rounded-full overflow-hidden border border-white/5">
+          <div className="h-1.5 w-full bg-[var(--color-surface)] rounded-[var(--radius-pill)] overflow-hidden border border-[var(--color-border)]">
             <motion.div
               initial={{ width: 0 }}
               animate={{ width: `${session.progress}%` }}
               className="h-full bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-primary)] relative"
             >
-              <div className="absolute inset-0 bg-white/20 animate-pulse" />
+              <div className="absolute inset-0 bg-white/20" />
             </motion.div>
           </div>
         </div>

--- a/src/renderer/src/components/chat/ThinkingBlock.tsx
+++ b/src/renderer/src/components/chat/ThinkingBlock.tsx
@@ -25,13 +25,13 @@ export function ThinkingBlock({ content }: ThinkingBlockProps) {
         <summary className="text-[10px] text-[var(--color-accent)] cursor-pointer hover:text-[var(--color-primary)] transition-colors list-none flex items-center gap-1.5 font-medium select-none">
           <div
             className={`w-1 h-3 rounded-full ${
-              isComplete ? 'bg-[var(--color-accent)]' : 'bg-yellow-400 animate-pulse'
+              isComplete ? 'bg-[var(--color-accent)]' : 'bg-[var(--color-warning)] shadow-[0_0_8px_var(--color-warning)]'
             }`}
           />
           <span>{isComplete ? 'Thinking Process' : 'Thinking...'}</span>
           <ChevronRight
             size={10}
-            className="group-open:rotate-90 transition-transform text-white/20"
+            className="group-open:rotate-90 transition-transform text-[var(--color-text-dim)]"
           />
         </summary>
         <motion.div
@@ -41,7 +41,7 @@ export function ThinkingBlock({ content }: ThinkingBlockProps) {
           transition={{ duration: 0.3, ease: 'easeOut' }}
           className="overflow-hidden"
         >
-          <div className="mt-2 text-[11px] leading-relaxed text-white/60 bg-black/20 rounded-md p-3 border border-white/5 font-mono shadow-inner whitespace-pre-wrap">
+          <div className="mt-2 text-[11px] leading-[var(--leading-relaxed)] text-[var(--color-text-secondary)] bg-[var(--color-surface)] rounded-[var(--radius-md)] p-3 border border-[var(--color-border)] font-[var(--font-family-mono)] shadow-inner whitespace-pre-wrap">
             {thinking}
           </div>
         </motion.div>

--- a/src/renderer/src/components/chat/ToolCallList.tsx
+++ b/src/renderer/src/components/chat/ToolCallList.tsx
@@ -115,7 +115,7 @@ function ToolRow({ tool }: { tool: ToolCall }) {
           ) : isDone ? (
             <CheckCircle2 size={14} className="text-[var(--color-success)]" />
           ) : (
-            <Activity size={14} className="text-[var(--color-primary)] animate-pulse" />
+            <Activity size={14} className="text-[var(--color-primary)]" />
           )}
         </div>
         <div className="flex-1 min-w-0">
@@ -254,7 +254,7 @@ export function ToolCallList({ toolCalls }: ToolCallListProps) {
           >
             {/* Left status strip — pulses when in-progress */}
             <div
-              className={cn('absolute left-0 top-0 bottom-0 w-1', !isDone && !hasError && 'animate-pulse')}
+              className={cn('absolute left-0 top-0 bottom-0 w-1', !isDone && !hasError && 'shadow-[0_0_8px_var(--color-primary)]')}
               style={{ backgroundColor: statusColor }}
             />
 
@@ -267,7 +267,7 @@ export function ToolCallList({ toolCalls }: ToolCallListProps) {
                   ) : isDone ? (
                     <CheckCircle2 size={16} className="text-[var(--color-success)]" />
                   ) : (
-                    <Activity size={16} className="text-[var(--color-primary)] animate-pulse" />
+                    <Activity size={16} className="text-[var(--color-primary)]" />
                   )}
                   <span className="font-semibold text-[var(--color-tool-text)] text-sm tracking-wide">
                     {agentLabel}

--- a/src/renderer/src/components/input/AttachmentBar.tsx
+++ b/src/renderer/src/components/input/AttachmentBar.tsx
@@ -2,16 +2,10 @@ import React from 'react'
 import { File as FileIcon, XCircle } from 'lucide-react'
 
 interface AttachmentBarProps {
-  /** Currently attached files */
   attachments: File[]
-  /** Remove an attachment by index */
   onRemove: (index: number) => void
 }
 
-/**
- * Horizontal pill list showing attached files with remove buttons.
- * Extracted from VoiceInput for independent rendering and tracking.
- */
 export function AttachmentBar({ attachments, onRemove }: AttachmentBarProps) {
   if (attachments.length === 0) return null
 
@@ -20,9 +14,9 @@ export function AttachmentBar({ attachments, onRemove }: AttachmentBarProps) {
       {attachments.map((file, index) => (
         <div
           key={`${file.name}-${index}`}
-          className="flex items-center gap-2 bg-white/10 rounded-full px-3 py-1 text-xs text-white/90 border border-white/10 animate-in fade-in zoom-in-95 duration-200"
+          className="flex items-center gap-2 bg-[var(--color-surface)] rounded-[var(--radius-pill)] px-3 py-1 text-[var(--text-xs)] text-[var(--color-text-primary)] border border-[var(--color-border)] animate-in fade-in zoom-in-95 duration-[var(--duration-fast)]"
         >
-          <FileIcon size={12} className="text-emerald-400" />
+          <FileIcon size={12} className="text-[var(--color-success)]" />
           <span
             className="max-w-[200px] truncate"
             title={(file as unknown as { path: string }).path || file.name}
@@ -31,7 +25,7 @@ export function AttachmentBar({ attachments, onRemove }: AttachmentBarProps) {
           </span>
           <button
             onClick={() => onRemove(index)}
-            className="hover:text-red-400 transition-colors"
+            className="text-[var(--color-text-muted)] hover:text-[var(--color-error)] transition-colors"
           >
             <XCircle size={14} />
           </button>

--- a/src/renderer/src/components/input/ChatInput.tsx
+++ b/src/renderer/src/components/input/ChatInput.tsx
@@ -258,7 +258,7 @@ export function ChatInput({ onSubmit, disabled = false, onAbort }: ChatInputProp
     <div className="card card-glass card-padding-sm border border-[var(--color-border)] p-[var(--space-3)] relative group hover:border-[var(--color-border-hover)]">
       {/* Notification Toast */}
       {notification && (
-        <div className="absolute -top-10 left-1/2 -translate-x-1/2 bg-[var(--color-success)]/90 text-white text-xs px-3 py-1.5 rounded-full shadow-lg whitespace-nowrap animate-in fade-in slide-in-from-bottom-2 duration-normal pointer-events-none border border-[var(--color-success)]/50 backdrop-blur-sm">
+        <div className="absolute -top-10 left-1/2 -translate-x-1/2 bg-[var(--color-success)]/90 text-[var(--color-text-inverse)] text-xs px-3 py-1.5 rounded-full shadow-lg whitespace-nowrap animate-in fade-in slide-in-from-bottom-2 duration-normal pointer-events-none border border-[var(--color-success)]/50 backdrop-blur-sm">
           {notification}
         </div>
       )}

--- a/src/renderer/src/components/input/ChatInput.tsx
+++ b/src/renderer/src/components/input/ChatInput.tsx
@@ -255,10 +255,10 @@ export function ChatInput({ onSubmit, disabled = false, onAbort }: ChatInputProp
   const hasContent = textInput.trim().length > 0 || attachments.length > 0
 
   return (
-    <div className="bg-[var(--color-card-elevated)]/90 backdrop-blur-xl border border-[var(--color-border)] rounded-input p-3 shadow-glass transition-all duration-normal relative group hover:border-[var(--color-border-hover)]">
+    <div className="card card-glass card-padding-sm border border-[var(--color-border)] p-[var(--space-3)] relative group hover:border-[var(--color-border-hover)]">
       {/* Notification Toast */}
       {notification && (
-        <div className="absolute -top-12 left-1/2 -translate-x-1/2 bg-emerald-500/90 text-white text-xs px-3 py-1.5 rounded-full shadow-lg whitespace-nowrap animate-in fade-in slide-in-from-bottom-2 duration-normal pointer-events-none border border-emerald-400/50 backdrop-blur-sm">
+        <div className="absolute -top-10 left-1/2 -translate-x-1/2 bg-[var(--color-success)]/90 text-white text-xs px-3 py-1.5 rounded-full shadow-lg whitespace-nowrap animate-in fade-in slide-in-from-bottom-2 duration-normal pointer-events-none border border-[var(--color-success)]/50 backdrop-blur-sm">
           {notification}
         </div>
       )}
@@ -268,14 +268,14 @@ export function ChatInput({ onSubmit, disabled = false, onAbort }: ChatInputProp
         <AttachmentBar attachments={attachments} onRemove={removeAttachment} />
 
         <div
-          className={`relative min-h-[44px] flex items-center transition-all duration-normal rounded-lg ${isDragging ? 'ring-2 ring-emerald-500/50 bg-emerald-500/10' : ''
+          className={`relative min-h-[44px] flex items-center transition-all duration-[var(--duration-normal)] rounded-[var(--radius-md)] ${isDragging ? 'ring-2 ring-[var(--color-success)]/50 bg-[var(--color-success)]/10' : ''
             }`}
           {...dragHandlers}
         >
           {/* Drag overlay */}
           {isDragging && (
             <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-10">
-              <div className="bg-emerald-500/20 backdrop-blur-sm border border-emerald-500/50 rounded-lg px-4 py-2 text-emerald-400 text-sm font-medium shadow-lg">
+              <div className="bg-[var(--color-success)]/20 backdrop-blur-sm border border-[var(--color-success)]/50 rounded-[var(--radius-md)] px-4 py-2 text-[var(--color-success)] text-sm font-[var(--font-weight-medium)] shadow-lg">
                 📄 Drop file to convert
               </div>
             </div>

--- a/src/renderer/src/components/input/InputToolbar.tsx
+++ b/src/renderer/src/components/input/InputToolbar.tsx
@@ -1,26 +1,17 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { Eye, EyeOff, Paperclip, FolderOpen, File as FileIcon } from 'lucide-react'
+import { Button } from '../primitives/Button'
 
 interface InputToolbarProps {
-  /** Current workspace path (null = none selected) */
   workspacePath: string | null
-  /** Whether headless mode is active */
   isHeadless: boolean
-  /** Toggle headless mode */
   onToggleHeadless: () => void
-  /** Open folder picker */
   onSelectFolder: () => void
-  /** Handle multiple file selection */
   onSelectFiles: (files: File[]) => void
-  /** Whether attachments currently exist in ChatInput */
   hasAttachments: boolean
-  /** Whether the input is disabled */
   disabled?: boolean
 }
 
-/**
- * Toolbar buttons alongside the input: unified workspace/file selector + headless toggle.
- */
 export function InputToolbar({
   workspacePath,
   isHeadless,
@@ -34,16 +25,13 @@ export function InputToolbar({
   const contextMenuRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  // Handle basic file selection from the hidden input
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length > 0) {
       onSelectFiles(Array.from(e.target.files))
-      // Reset input so the same files can be chosen again
       e.target.value = ''
     }
   }
 
-  // Close dropdown when clicking outside
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       if (contextMenuRef.current && !contextMenuRef.current.contains(e.target as Node)) {
@@ -71,10 +59,10 @@ export function InputToolbar({
         <button
           onClick={() => setShowContextMenu(!showContextMenu)}
           disabled={disabled}
-          className={`p-2 mb-[1px] rounded-lg transition-all h-[44px] w-[36px] flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] ${workspacePath
+          className={`p-2 mb-[1px] rounded-[var(--radius-lg)] transition-all h-[44px] w-[36px] flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] ${workspacePath
               ? 'bg-[var(--color-brand-teal)]/20 text-[var(--color-brand-teal)] hover:bg-[var(--color-brand-teal)]/30'
               : hasAttachments
-                ? 'bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30'
+                ? 'bg-[var(--color-success)]/20 text-[var(--color-success)] hover:bg-[var(--color-success)]/30'
                 : 'bg-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-surface)]'
             } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
           title={workspacePath ? `Workspace: ${workspacePath}` : 'Select workspace or files'}
@@ -84,21 +72,21 @@ export function InputToolbar({
 
         {/* Dropdown Menu */}
         {showContextMenu && (
-          <div className="absolute bottom-full mb-2 -right-4 bg-[var(--color-card-elevated)] border border-[var(--color-border)] rounded-xl shadow-glass overflow-hidden min-w-[200px] animate-in fade-in slide-in-from-bottom-2 duration-fast z-50">
+          <div className="absolute bottom-full mb-2 -right-4 bg-[var(--color-card-elevated)] border border-[var(--color-border)] rounded-[var(--radius-xl)] shadow-[var(--shadow-glass)] overflow-hidden min-w-[200px] animate-in fade-in slide-in-from-bottom-2 duration-[var(--duration-fast)] z-50">
             {/* Select Workspace */}
             <button
               onClick={() => {
                 onSelectFolder()
                 setShowContextMenu(false)
               }}
-              className="w-full flex items-center gap-3 px-4 py-3 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-surface)] hover:text-[var(--color-primary)] transition-colors"
+              className="w-full flex items-center gap-3 px-4 py-3 text-[var(--text-sm)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface)] hover:text-[var(--color-primary)] transition-colors"
             >
               <FolderOpen
                 size={16}
                 className={workspacePath ? 'text-[var(--color-brand-teal)]' : 'text-[var(--color-text-muted)]'}
               />
               <div className="flex flex-col items-start">
-                <span className="font-medium">Select Workspace</span>
+                <span className="font-[var(--font-weight-medium)]">Select Workspace</span>
                 {workspacePath && (
                   <span className="text-[10px] text-[var(--color-brand-teal)]/70 max-w-[160px] truncate">
                     {workspacePath.split(/[/\\]/).pop()}
@@ -113,13 +101,13 @@ export function InputToolbar({
                 fileInputRef.current?.click()
                 setShowContextMenu(false)
               }}
-              className="w-full flex items-center gap-3 px-4 py-3 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-surface)] hover:text-[var(--color-primary)] transition-colors"
+              className="w-full flex items-center gap-3 px-4 py-3 text-[var(--text-sm)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface)] hover:text-[var(--color-primary)] transition-colors"
             >
               <FileIcon
                 size={16}
-                className={hasAttachments ? 'text-emerald-400' : 'text-[var(--color-text-muted)]'}
+                className={hasAttachments ? 'text-[var(--color-success)]' : 'text-[var(--color-text-muted)]'}
               />
-              <span className="font-medium">Select Files</span>
+              <span className="font-[var(--font-weight-medium)]">Select Files</span>
             </button>
           </div>
         )}
@@ -129,8 +117,8 @@ export function InputToolbar({
       <button
         onClick={onToggleHeadless}
         disabled={disabled}
-        className={`p-2 mb-[1px] rounded-lg transition-all h-[44px] w-[36px] flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] ${isHeadless
-            ? 'bg-purple-500/20 text-purple-400 hover:bg-purple-500/30'
+        className={`p-2 mb-[1px] rounded-[var(--radius-lg)] transition-all h-[44px] w-[36px] flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] ${isHeadless
+            ? 'bg-[var(--color-accent)]/20 text-[var(--color-accent)] hover:bg-[var(--color-accent)]/30'
             : 'bg-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-surface)]'
           } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
         title={

--- a/src/renderer/src/components/input/SendButton.tsx
+++ b/src/renderer/src/components/input/SendButton.tsx
@@ -1,44 +1,34 @@
 import React from 'react'
 import { Send, Square } from 'lucide-react'
+import { Button } from '../primitives/Button'
 
 interface SendButtonProps {
-  /** Whether the input is disabled (processing) */
   disabled?: boolean
-  /** Abort handler — if provided while disabled, shows a stop button */
   onAbort?: () => void
-  /** Submit handler */
   onSubmit: () => void
-  /** Whether there's content to send */
   hasContent: boolean
 }
 
-/**
- * Submit / Stop generation button.
- *
- * Two states:
- *   1. Processing + onAbort available → red stop button
- *   2. Otherwise → send button (enabled only when hasContent)
- */
 export function SendButton({
   disabled = false,
   onAbort,
   onSubmit,
   hasContent,
 }: SendButtonProps) {
-  // Stop button during generation
   if (disabled && onAbort) {
     return (
-      <button
+      <Button
+        variant="ghost"
+        size="md"
         onClick={onAbort}
-        className="p-2 mb-[1px] rounded-lg transition-all bg-red-500/20 hover:bg-red-500/30 text-red-400 h-[44px] w-[36px] flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
+        className="w-[36px] h-[44px] p-2 mb-[1px] text-[var(--color-error)] hover:bg-[var(--color-error)]/20"
         title="Stop Generation"
       >
         <Square size={18} className="fill-current" />
-      </button>
+      </Button>
     )
   }
 
-  // Send button
   return (
     <button
       type="button"
@@ -52,7 +42,7 @@ export function SendButton({
       aria-disabled={disabled || !hasContent}
       aria-label="Send message"
       data-testid="send-button"
-      className={`p-2 mb-[1px] rounded-lg transition-all h-[44px] w-[36px] flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] ${hasContent && !disabled
+      className={`p-2 mb-[1px] rounded-[var(--radius-lg)] transition-all h-[44px] w-[36px] flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] ${hasContent && !disabled
           ? 'bg-[var(--color-text-primary)] text-[var(--color-bg-dark)] hover:opacity-80'
           : 'bg-transparent text-[var(--color-text-dim)] cursor-not-allowed'
         }`}

--- a/src/renderer/src/components/input/VoiceButton.tsx
+++ b/src/renderer/src/components/input/VoiceButton.tsx
@@ -1,31 +1,17 @@
 import React from 'react'
 import { Mic, Square } from 'lucide-react'
+import { Button } from '../primitives/Button'
 
 interface VoiceButtonProps {
-  /** Whether speech is actively listening */
   isListening: boolean
-  /** Whether the speech engine is initializing */
   isInitializing: boolean
-  /** Whether this is the first-time setup (downloading model) */
   isFirstSetup: boolean
-  /** Download progress percentage (0-100) */
   setupProgress?: number
-  /** Whether speech-to-text is supported */
   sttSupported: boolean
-  /** Whether the entire input is disabled */
   disabled?: boolean
-  /** Click handler for mic toggle */
   onClick: () => void
 }
 
-/**
- * Microphone toggle button with download progress indicator.
- *
- * Three states:
- *   1. First setup — circular progress ring showing model download
- *   2. Listening/initializing — red pulsing stop button
- *   3. Idle — standard mic icon
- */
 export function VoiceButton({
   isListening,
   isInitializing,
@@ -35,7 +21,6 @@ export function VoiceButton({
   disabled = false,
   onClick,
 }: VoiceButtonProps) {
-  // State 1: Downloading speech model
   if (isFirstSetup) {
     return (
       <div
@@ -60,13 +45,13 @@ export function VoiceButton({
               stroke="currentColor"
               strokeWidth="3"
               fill="transparent"
-              className="text-emerald-500 transition-all duration-normal ease-out"
+              className="text-[var(--color-success)] transition-all duration-[var(--duration-normal)] ease-[var(--ease-out)]"
               strokeDasharray={88}
               strokeDashoffset={88 - (88 * setupProgress) / 100}
               strokeLinecap="round"
             />
           </svg>
-          <div className="absolute inset-0 flex items-center justify-center text-[8px] font-bold text-emerald-400">
+          <div className="absolute inset-0 flex items-center justify-center text-[8px] font-[var(--font-weight-bold)] text-[var(--color-success)]">
             {Math.round(setupProgress)}%
           </div>
         </div>
@@ -74,12 +59,11 @@ export function VoiceButton({
     )
   }
 
-  // State 2: Recording / initializing
   if (isListening || isInitializing) {
     return (
       <button
         onClick={onClick}
-        className="p-3 mb-[1px] rounded-xl flex items-center justify-center transition-all active:scale-95 bg-red-500/20 hover:bg-red-500/30 text-red-400 animate-pulse ring-1 ring-red-500/50 h-[44px] w-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
+        className="p-3 mb-[1px] rounded-[var(--radius-xl)] flex items-center justify-center transition-all active:scale-[0.95] bg-[var(--color-error)]/20 hover:bg-[var(--color-error)]/30 text-[var(--color-error)] ring-1 ring-[var(--color-error)]/50 h-[44px] w-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
         title="Stop Recording"
       >
         <Square size={16} className="fill-current" />
@@ -87,17 +71,16 @@ export function VoiceButton({
     )
   }
 
-  // State 3: Idle
   return (
-    <button
+    <Button
+      variant="secondary"
+      size="md"
       onClick={onClick}
       disabled={disabled || !sttSupported}
-      className={`p-3 mb-[1px] rounded-xl flex items-center justify-center transition-all active:scale-95 shadow-lg group bg-[var(--color-surface)] hover:bg-[var(--color-border)] text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] h-[44px] w-[44px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] ${
-        disabled || !sttSupported ? 'opacity-50 cursor-not-allowed' : ''
-      }`}
+      className="w-[44px] h-[44px] p-3 mb-[1px]"
       title="Start Voice Mode"
     >
       <Mic size={20} />
-    </button>
+    </Button>
   )
 }

--- a/src/renderer/src/components/mcp/McpServerCard.tsx
+++ b/src/renderer/src/components/mcp/McpServerCard.tsx
@@ -13,6 +13,9 @@ import {
   Zap,
 } from "lucide-react";
 import { MCPServer } from "../../lib/mcp";
+import { Card, CardContent } from "../primitives/Card";
+import { StatusBadge } from "../primitives/StatusDot";
+import { Button } from "../primitives/Button";
 
 interface McpServerCardProps {
   server: MCPServer;
@@ -44,12 +47,11 @@ export function McpServerCard({
   onToggleAutoConnect,
 }: McpServerCardProps) {
   return (
-    <div
-      data-testid={`mcp-server-card-${server.name.toLowerCase().replace(/\s+/g, '-')}`}
-      className={`bg-[var(--color-card-elevated)] border rounded-xl overflow-hidden shadow-sm hover:border-[var(--color-brand-teal)]/30 transition-colors ${isEditing
-          ? "border-[var(--color-brand-teal)]/50 ring-1 ring-[var(--color-brand-teal)]/20"
-          : "border-[var(--color-border)]"
-        }`}
+    <Card 
+      variant="elevated" 
+      padding="none"
+      hoverable={!isEditing}
+      className={`overflow-hidden ${isEditing ? 'border-[var(--color-brand-teal)]/50 ring-1 ring-[var(--color-brand-teal)]/20' : ''}`}
     >
       {/* Server Header */}
       <div className="flex items-center gap-4 p-4">
@@ -61,7 +63,7 @@ export function McpServerCard({
         </button>
 
         <div
-          className={`p-2.5 rounded-lg ${server.connected
+          className={`p-2.5 rounded-[var(--radius-md)] ${server.connected
               ? "bg-[var(--color-brand-teal)]/10 text-[var(--color-brand-teal)]"
               : "bg-[var(--color-surface-hover)] text-[var(--color-text-muted)]"
             }`}
@@ -71,23 +73,18 @@ export function McpServerCard({
 
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-3">
-            <h3 className="font-medium text-[var(--color-text-primary)] truncate">
+            <h3 className="font-[var(--font-weight-medium)] text-[var(--color-text-primary)] truncate">
               {server.name}
             </h3>
             {server.connected ? (
-              <span className="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-green-500/10 text-green-400 text-[10px] font-medium uppercase tracking-wide border border-green-500/20">
-                <div className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
-                Active
-              </span>
+              <StatusBadge variant="success" label="Active" animated />
             ) : server.error ? (
-              <span className="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-red-500/10 text-red-400 text-[10px] font-medium uppercase tracking-wide border border-red-500/20">
-                Error
-              </span>
+              <StatusBadge variant="error" label="Error" />
             ) : (
-              <span className="text-xs text-white/30">Offline</span>
+              <span className="text-[var(--text-xs)] text-[var(--color-text-dim)]">Offline</span>
             )}
           </div>
-          <p className="text-xs text-[var(--color-text-muted)] mt-0.5 truncate font-mono">
+          <p className="text-[var(--text-xs)] text-[var(--color-text-muted)] mt-0.5 truncate font-[var(--font-family-mono)]">
             {server.type === "stdio"
               ? `${server.command} ${(server.args || []).join(" ")}`
               : server.url}
@@ -95,24 +92,24 @@ export function McpServerCard({
         </div>
 
         <div className="flex items-center gap-2">
-          <button
+          <Button
+            variant={isEditing ? 'primary' : 'ghost'}
+            size="sm"
             onClick={onEdit}
-            className={`p-2 rounded-lg transition-all ${isEditing
-                ? "bg-[var(--color-brand-teal)] text-white"
-                : "bg-[var(--color-surface-hover)] text-[var(--color-text-muted)] hover:bg-[var(--color-brand-teal)]/10 hover:text-[var(--color-brand-teal)]"
-              }`}
             title="Edit configuration"
           >
             <Edit2 size={18} />
-          </button>
+          </Button>
 
-          <button
+          <Button
+            variant={server.connected ? 'ghost' : 'ghost'}
+            size="sm"
             onClick={onToggleConnection}
             disabled={isConnecting}
-            className={`p-2 rounded-lg transition-all ${server.connected
-                ? "bg-red-500/10 text-red-400 hover:bg-red-500/20"
-                : "bg-green-500/10 text-green-400 hover:bg-green-500/20"
-              } disabled:opacity-50`}
+            className={server.connected 
+              ? 'text-[var(--color-error)] hover:bg-[var(--color-error)]/10' 
+              : 'text-[var(--color-success)] hover:bg-[var(--color-success)]/10'
+            }
             title={server.connected ? "Disconnect" : "Connect"}
           >
             {isConnecting ? (
@@ -120,16 +117,17 @@ export function McpServerCard({
             ) : (
               <Power size={18} />
             )}
-          </button>
+          </Button>
 
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={onRemove}
-            className="p-2 rounded-lg bg-[var(--color-surface-hover)] text-[var(--color-text-muted)] 
-                           hover:bg-[var(--color-error)]/10 hover:text-[var(--color-error)] transition-all border border-transparent hover:border-[var(--color-error)]/20"
+            className="text-[var(--color-text-muted)] hover:text-[var(--color-error)] hover:bg-[var(--color-error)]/10"
             title="Remove server"
           >
             <Trash2 size={18} />
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -137,19 +135,19 @@ export function McpServerCard({
       {(isExpanded || server.error) && (
         <div className="border-t border-[var(--color-border)] bg-[var(--color-input-bg)]">
           {server.error && (
-            <div className="p-4 bg-red-500/5 border-b border-red-500/10">
+            <div className="p-4 bg-[var(--color-error)]/5 border-b border-[var(--color-error)]/10">
               <div className="flex items-start gap-3">
                 <AlertCircle
                   size={16}
-                  className="text-red-400 shrink-0 mt-0.5"
+                  className="text-[var(--color-error)] shrink-0 mt-0.5"
                 />
                 <div className="flex-1 min-w-0">
-                  <div className="text-xs text-red-200 leading-relaxed font-sans whitespace-pre-wrap">
+                  <div className="text-[var(--text-xs)] text-[var(--color-error)] leading-[var(--leading-relaxed)] whitespace-pre-wrap">
                     {server.error.split("`").map((part, i) =>
                       i % 2 === 1 ? (
                         <code
                           key={i}
-                          className="bg-red-500/20 px-1.5 py-0.5 rounded text-red-300 font-mono text-[11px] mx-0.5 border border-red-500/20 select-all cursor-pointer hover:bg-red-500/30 transition-colors"
+                          className="bg-[var(--color-error)]/20 px-1.5 py-0.5 rounded text-[var(--color-error)] font-[var(--font-family-mono)] text-[11px] mx-0.5 border border-[var(--color-error)]/20 select-all cursor-pointer hover:bg-[var(--color-error)]/30 transition-colors"
                           title="Click to select"
                         >
                           {part}
@@ -160,13 +158,15 @@ export function McpServerCard({
                     )}
                   </div>
 
-                  <button
+                  <Button
+                    variant="ghost"
+                    size="sm"
                     onClick={onTroubleshoot}
-                    className="mt-4 flex items-center gap-2 px-3 py-1.5 bg-[var(--color-surface-hover)] border border-[var(--color-border)] rounded-lg text-[11px] text-[var(--color-brand-teal)] hover:bg-[var(--color-brand-teal)]/10 hover:border-[var(--color-brand-teal)]/30 transition-all font-medium"
+                    className="mt-4 text-[var(--color-brand-teal)] hover:bg-[var(--color-brand-teal)]/10"
                   >
                     <MessageSquare size={14} />
                     Troubleshoot with AI
-                  </button>
+                  </Button>
                 </div>
               </div>
             </div>
@@ -175,18 +175,17 @@ export function McpServerCard({
           {isExpanded && (
             <div className="p-4 space-y-4">
               {/* Auto-Connect Toggle */}
-              <div className="flex items-center justify-between p-3 rounded-lg bg-white/5 border border-white/5">
+              <div className="flex items-center justify-between p-3 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)]">
                 <div className="flex items-center gap-3">
                   <Zap
                     size={16}
-                    className={`${server.autoConnect ? "text-[var(--color-brand-teal)]" : "text-[var(--color-text-muted)]"
-                      }`}
+                    className={server.autoConnect ? "text-[var(--color-brand-teal)]" : "text-[var(--color-text-muted)]"}
                   />
                   <div>
-                    <p className="text-[var(--color-text-primary)] text-sm font-medium">
+                    <p className="text-[var(--color-text-primary)] text-[var(--text-sm)] font-[var(--font-weight-medium)]">
                       Auto-connect on startup
                     </p>
-                    <p className="text-[var(--color-text-muted)] text-xs">
+                    <p className="text-[var(--color-text-muted)] text-[var(--text-xs)]">
                       {server.autoConnect
                         ? "This server will automatically connect when the app starts"
                         : "This server requires manual connection"}
@@ -195,7 +194,7 @@ export function McpServerCard({
                 </div>
                 <input
                   type="checkbox"
-                  className="toggle toggle-success toggle-sm"
+                  className="toggle"
                   checked={server.autoConnect}
                   onChange={() => onToggleAutoConnect(!server.autoConnect)}
                   title="Toggle auto-connect"
@@ -205,16 +204,16 @@ export function McpServerCard({
               {/* Tools List */}
               {server.connected && server.tools.length > 0 ? (
                 <div>
-                  <p className="text-[var(--color-text-muted)] text-xs mb-3 uppercase tracking-wider font-medium">
+                  <p className="text-[var(--color-text-muted)] text-[var(--text-xs)] mb-3 uppercase tracking-wider font-[var(--font-weight-medium)]">
                     Available Tools ({server.tools.length})
                   </p>
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                     {server.tools.map((tool) => (
                       <div
                         key={tool.name}
-                        className="p-2 rounded bg-white/5 border border-white/5 flex flex-col gap-1"
+                        className="p-2 rounded-[var(--radius-md)] bg-[var(--color-surface)] border border-[var(--color-border)] flex flex-col gap-1"
                       >
-                        <span className="text-[var(--color-brand-teal)] text-xs font-mono font-medium">
+                        <span className="text-[var(--color-brand-teal)] text-[var(--text-xs)] font-[var(--font-family-mono)] font-[var(--font-weight-medium)]">
                           {tool.name}
                         </span>
                         <span className="text-[var(--color-text-muted)] text-[10px] truncate">
@@ -226,17 +225,17 @@ export function McpServerCard({
                 </div>
               ) : server.connected ? (
                 <div className="space-y-2">
-                  <p className="text-white/30 text-sm italic">
+                  <p className="text-[var(--color-text-dim)] text-[var(--text-sm)] italic">
                     No tools exposed by this server.
                   </p>
                   {(server.name.includes("sequential-thinking") ||
                     server.name.includes("sequential") ||
                     server.description.toLowerCase().includes("reasoning")) && (
-                      <div className="p-3 rounded-lg bg-[var(--color-brand-teal)]/10 border border-[var(--color-brand-teal)]/20">
-                        <p className="text-[var(--color-brand-teal)] text-xs font-medium mb-1">
+                      <div className="p-3 rounded-[var(--radius-md)] bg-[var(--color-brand-teal)]/10 border border-[var(--color-brand-teal)]/20">
+                        <p className="text-[var(--color-brand-teal)] text-[var(--text-xs)] font-[var(--font-weight-medium)] mb-1">
                           ℹ️ Reasoning Server
                         </p>
-                        <p className="text-[var(--color-text-secondary)] text-[11px] leading-relaxed">
+                        <p className="text-[var(--color-text-secondary)] text-[11px] leading-[var(--leading-relaxed)]">
                           This server works differently - it provides reasoning
                           capabilities rather than traditional tools. It will be
                           used automatically by the AI for complex multi-step
@@ -246,7 +245,7 @@ export function McpServerCard({
                     )}
                 </div>
               ) : (
-                <p className="text-white/30 text-sm italic">
+                <p className="text-[var(--color-text-dim)] text-[var(--text-sm)] italic">
                   Connect to inspect available tools.
                 </p>
               )}
@@ -254,6 +253,6 @@ export function McpServerCard({
           )}
         </div>
       )}
-    </div>
+    </Card>
   );
 }

--- a/src/renderer/src/components/primitives/Button.tsx
+++ b/src/renderer/src/components/primitives/Button.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { cn } from '../../lib/utils'
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'glass'
+type ButtonSize = 'sm' | 'md' | 'lg'
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  children: React.ReactNode
+  fullWidth?: boolean
+}
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  children,
+  className,
+  fullWidth = false,
+  disabled = false,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      className={cn(
+        'btn',
+        `btn-${variant}`,
+        `btn-${size}`,
+        fullWidth && 'btn-full-width',
+        className
+      )}
+      disabled={disabled}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/renderer/src/components/primitives/Card.tsx
+++ b/src/renderer/src/components/primitives/Card.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { cn } from '../../lib/utils'
+
+type CardVariant = 'default' | 'elevated' | 'glass' | 'outlined'
+type CardPadding = 'none' | 'sm' | 'md' | 'lg'
+
+interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: CardVariant
+  padding?: CardPadding
+  hoverable?: boolean
+}
+
+export function Card({
+  variant = 'default',
+  padding = 'md',
+  hoverable = false,
+  className,
+  children,
+  ...props
+}: CardProps) {
+  return (
+    <div
+      className={cn(
+        'card',
+        `card-${variant}`,
+        `card-padding-${padding}`,
+        hoverable && 'card-hoverable',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+export function CardHeader({ className, children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('card-header', className)} {...props}>{children}</div>
+}
+
+export function CardTitle({ className, children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={cn('card-title', className)} {...props}>{children}</h3>
+}
+
+export function CardDescription({ className, children, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
+  return <p className={cn('card-description', className)} {...props}>{children}</p>
+}
+
+export function CardContent({ className, children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('', className)} {...props}>{children}</div>
+}
+
+export function CardFooter({ className, children, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('card-footer', className)} {...props}>{children}</div>
+}

--- a/src/renderer/src/components/primitives/CollapsibleSection.tsx
+++ b/src/renderer/src/components/primitives/CollapsibleSection.tsx
@@ -35,7 +35,7 @@ export function CollapsibleSection({
 }: CollapsibleSectionProps) {
   return (
     <details className={cn('group', className)} open={defaultOpen}>
-      <summary className="text-[10px] text-white/40 cursor-pointer hover:text-white/60 transition-colors list-none flex items-center gap-1.5 font-medium select-none">
+      <summary className="text-[10px] text-[var(--color-text-dim)] cursor-pointer hover:text-[var(--color-text-muted)] transition-colors list-none flex items-center gap-1.5 font-medium select-none">
         <div
           className={cn(
             'w-1 h-3 rounded-full',
@@ -46,7 +46,7 @@ export function CollapsibleSection({
         <span>{label}</span>
         <ChevronRight
           size={10}
-          className="group-open:rotate-90 transition-transform text-white/20"
+          className="group-open:rotate-90 transition-transform text-[var(--color-text-dim)]"
         />
       </summary>
 

--- a/src/renderer/src/components/primitives/CollapsibleSection.tsx
+++ b/src/renderer/src/components/primitives/CollapsibleSection.tsx
@@ -40,7 +40,7 @@ export function CollapsibleSection({
           className={cn(
             'w-1 h-3 rounded-full',
             statusColor,
-            statusPulse && 'animate-pulse'
+            statusPulse && 'shadow-[0_0_8px_var(--color-primary)]'
           )}
         />
         <span>{label}</span>

--- a/src/renderer/src/components/primitives/StatusDot.tsx
+++ b/src/renderer/src/components/primitives/StatusDot.tsx
@@ -1,41 +1,58 @@
 import React from 'react'
 import { cn } from '../../lib/utils'
 
+type StatusVariant = 'success' | 'warning' | 'error' | 'idle' | 'active'
+type StatusSize = 'sm' | 'md' | 'lg'
+
 interface StatusDotProps {
-  /** Color class (e.g. 'bg-green-400', 'bg-[var(--color-primary)]') */
-  color?: string
-  /** Whether the dot should animate with a pulse */
-  pulse?: boolean
-  /** Size variant */
-  size?: 'sm' | 'md'
-  /** Additional class names */
+  variant?: StatusVariant
+  size?: StatusSize
+  animated?: boolean
   className?: string
 }
 
-const SIZE_CLASSES = {
-  sm: 'w-1 h-1',
-  md: 'w-1.5 h-1.5',
-} as const
-
-/**
- * Tiny animated status indicator dot.
- * Used throughout the UI, such as in tool call progress, connection status, and session indicators.
- */
 export function StatusDot({
-  color = 'bg-green-400',
-  pulse = false,
+  variant = 'idle',
   size = 'md',
+  animated = false,
   className,
 }: StatusDotProps) {
   return (
     <span
       className={cn(
-        'rounded-full inline-block',
-        SIZE_CLASSES[size],
-        color,
-        pulse && 'animate-pulse',
+        'status-dot',
+        `status-dot-${variant}`,
+        `status-dot-${size}`,
+        animated && 'status-dot-animated',
         className
       )}
     />
+  )
+}
+
+interface StatusBadgeProps {
+  variant?: StatusVariant
+  label: string
+  showDot?: boolean
+  animated?: boolean
+  className?: string
+}
+
+export function StatusBadge({
+  variant = 'idle',
+  label,
+  showDot = true,
+  animated = false,
+  className,
+}: StatusBadgeProps) {
+  const dotVariant = variant === 'idle' ? 'idle' : variant
+
+  return (
+    <span className={cn('status-badge', `status-badge-${variant}`, className)}>
+      {showDot && (
+        <StatusDot variant={dotVariant} size="sm" animated={animated && variant !== 'idle'} />
+      )}
+      {label}
+    </span>
   )
 }

--- a/src/renderer/src/components/settings/MemoryPreferencesPanel.tsx
+++ b/src/renderer/src/components/settings/MemoryPreferencesPanel.tsx
@@ -110,7 +110,7 @@ export function MemoryPreferencesPanel() {
             <div className="bg-[var(--color-card-elevated)] border border-[var(--color-border)] rounded-xl p-6">
                 <div className="flex items-center justify-between mb-4">
                     <h4 className="font-medium flex items-center gap-2 text-[var(--color-text-primary)]">
-                        <span className="w-2 h-2 rounded-full bg-[var(--color-success)] animate-pulse"></span>
+                        <span className="w-2 h-2 rounded-full bg-[var(--color-success)] shadow-[0_0_8px_var(--color-success)]"></span>
                         Active Memory Stats
                     </h4>
                     <button 

--- a/src/renderer/src/components/settings/llm/AntigravityLinkButton.tsx
+++ b/src/renderer/src/components/settings/llm/AntigravityLinkButton.tsx
@@ -49,7 +49,7 @@ export function AntigravityLinkButton({ variant = 'compact' }: AntigravityLinkBu
                 <div>
                     <p className="text-sm font-medium text-[var(--color-text-primary)]">{antigravityEmail}</p>
                     <p className="text-[10px] text-[var(--color-success)] flex items-center gap-1">
-                        <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-success)] animate-pulse inline-block" />
+                        <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-success)] shadow-[0_0_8px_var(--color-success)] inline-block" />
                         Linked and Active
                     </p>
                 </div>

--- a/src/renderer/src/components/sidebar/ActiveAgentsList.tsx
+++ b/src/renderer/src/components/sidebar/ActiveAgentsList.tsx
@@ -1,35 +1,34 @@
 import React from 'react'
 import { Search, Calendar, MapPin, Activity } from 'lucide-react'
 
-// Dummy data for design visualization logic
 const AGENTS = [
-  { id: 'research', label: 'Research', icon: Search, activeCount: 2, totalCount: 3, dotColor: 'bg-emerald-500' },
-  { id: 'planning', label: 'Planning', icon: Calendar, activeCount: 0, totalCount: 0, dotColor: 'bg-amber-500' },
-  { id: 'local', label: 'Local', icon: MapPin, activeCount: 0, totalCount: 0, dotColor: 'bg-amber-500' },
-  { id: 'health', label: 'Health', icon: Activity, activeCount: 0, totalCount: 0, dotColor: 'bg-amber-500' },
+  { id: 'research', label: 'Research', icon: Search, activeCount: 2, totalCount: 3, dotColor: 'bg-[var(--color-success)]' },
+  { id: 'planning', label: 'Planning', icon: Calendar, activeCount: 0, totalCount: 0, dotColor: 'bg-[var(--color-warning)]' },
+  { id: 'local', label: 'Local', icon: MapPin, activeCount: 0, totalCount: 0, dotColor: 'bg-[var(--color-warning)]' },
+  { id: 'health', label: 'Health', icon: Activity, activeCount: 0, totalCount: 0, dotColor: 'bg-[var(--color-warning)]' },
 ]
 
 export function ActiveAgentsList() {
   return (
     <div className="px-5 py-4">
-      <h3 className="text-[10px] font-bold text-white/40 tracking-wider uppercase mb-3">
+      <h3 className="text-[10px] font-[var(--font-weight-bold)] text-[var(--color-text-dim)] tracking-wider uppercase mb-3">
         Active Agents
       </h3>
       <div className="flex flex-col gap-1">
         {AGENTS.map((agent) => (
           <div
             key={agent.id}
-            className="flex items-center justify-between py-2 px-2 -mx-2 rounded-lg hover:bg-[var(--color-surface)] transition-colors text-white/70 hover:text-white cursor-pointer group"
+            className="flex items-center justify-between py-2 px-2 -mx-2 rounded-[var(--radius-lg)] hover:bg-[var(--color-surface)] transition-colors text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] cursor-pointer group"
           >
             <div className="flex items-center gap-3">
               <agent.icon size={16} className="text-[var(--color-primary)] opacity-80 group-hover:opacity-100 transition-opacity" />
-              <span className="text-xs font-medium">{agent.label}</span>
+              <span className="text-[var(--text-xs)] font-[var(--font-weight-medium)]">{agent.label}</span>
             </div>
             <div className="flex items-center gap-2">
-              <span className="text-[10px] font-mono text-white/40">
+              <span className="text-[10px] font-[var(--font-family-mono)] text-[var(--color-text-dim)]">
                 {agent.activeCount}/{agent.totalCount}
               </span>
-              <span className={`w-2 h-2 rounded-full ${agent.dotColor} ${agent.activeCount > 0 ? 'animate-pulse shadow-[0_0_8px_rgba(16,185,129,0.5)]' : ''}`} />
+              <span className={`w-2 h-2 rounded-full ${agent.dotColor} ${agent.activeCount > 0 ? 'shadow-[0_0_8px_var(--color-success)]' : ''}`} />
             </div>
           </div>
         ))}

--- a/src/renderer/src/components/sidebar/RecentSessionsList.tsx
+++ b/src/renderer/src/components/sidebar/RecentSessionsList.tsx
@@ -123,7 +123,7 @@ export function RecentSessionsList({ onViewChange }: RecentSessionsListProps) {
                   <button onClick={(e) => startEditing(e, session)} className="p-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] rounded">
                     <Edit2 size={12} />
                   </button>
-                  <button onClick={(e) => handleDelete(e, session.id)} className="p-1 text-[var(--color-text-muted)] hover:text-red-400 rounded">
+                  <button onClick={(e) => handleDelete(e, session.id)} className="p-1 text-[var(--color-text-muted)] hover:text-[var(--color-error)] rounded">
                     <Trash2 size={12} />
                   </button>
                 </div>

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -4,7 +4,7 @@ import { Network } from 'lucide-react'
 export function SidebarHeader() {
   return (
     <div className="flex items-center gap-3 px-5 py-6">
-      <div className="w-8 h-8 rounded-lg bg-[#1a2133] flex items-center justify-center flex-shrink-0 text-[var(--color-primary)]">
+      <div className="w-8 h-8 rounded-lg bg-[var(--color-surface)] flex items-center justify-center flex-shrink-0 text-[var(--color-primary)]">
         <Network size={18} />
       </div>
       <div className="flex flex-col">

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -30,7 +30,7 @@
 }
 
 @layer components {
-  /* Custom toggle styles (replacing missing DaisyUI) */
+  /* Custom toggle styles - Dark theme optimized */
   .toggle {
     appearance: none;
     -webkit-appearance: none;
@@ -38,7 +38,7 @@
     width: 3rem; /* 48px */
     height: 1.5rem; /* 24px */
     border-radius: 9999px;
-    background-color: var(--color-surface-hover);
+    background-color: var(--color-surface);
     border: 1px solid var(--color-border);
     cursor: pointer;
     transition: background-color 0.2s ease, border-color 0.2s ease;
@@ -51,26 +51,28 @@
     top: 50%;
     left: 2px;
     transform: translateY(-50%);
-    width: 1.25rem; /* 20px */
-    height: 1.25rem; /* 20px */
+    width: 1.125rem; /* 18px */
+    height: 1.125rem; /* 18px */
     border-radius: 9999px;
-    background-color: var(--color-text-muted);
+    background-color: var(--color-text-dim);
     transition: transform 0.2s ease, background-color 0.2s ease;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.2);
   }
   
   .toggle:checked, .toggle-success:checked {
     background-color: var(--color-success);
     border-color: var(--color-success);
+    box-shadow: 0 0 8px rgba(48, 209, 88, 0.3);
   }
   
   .toggle:checked::before, .toggle-success:checked::before {
-    transform: translate(1.375rem, -50%); /* 22px to right for standard sizing based on real rendering */
-    background-color: #ffffff;
+    transform: translate(1.375rem, -50%);
+    background-color: white;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.3);
   }
   
   .toggle:focus-visible {
-    outline: 2px solid var(--color-brand-teal);
+    outline: 2px solid var(--color-primary);
     outline-offset: 2px;
   }
 

--- a/src/renderer/src/lib/agent/OrchestrationService.ts
+++ b/src/renderer/src/lib/agent/OrchestrationService.ts
@@ -211,9 +211,9 @@ export async function executeParallelSubAgents(
         try {
             const result = await subAgent.chat(instruction);
             const resultContent =
-                typeof result.content === "string"
+                typeof result?.content === "string"
                     ? result.content
-                    : (result.content as any[]).map((c: any) => (c.type === "text" ? c.text : "")).join("");
+                    : (result?.content as any[])?.map((c: any) => (c.type === "text" ? c.text : "")).join("") ?? "";
 
             // Detect sub-agent bailout (max consecutive errors)
             const isBailout = resultContent.includes("consecutive errors") ||

--- a/src/renderer/src/styles/design-tokens.css
+++ b/src/renderer/src/styles/design-tokens.css
@@ -14,129 +14,435 @@
 
 :root {
   /* ── Colors ──────────────────────────────────────────────────────── */
-  --color-primary: #4facfe;
-  --color-primary-hover: #00f2fe;
-  --color-accent: #3b82f6;
-  --color-brand-teal: #00a896;    /* Secondary brand teal used for CTAs */
-  --color-bg-dark: #0b0c0f;      /* Very dark, almost black background */
-  --color-card-dark: #16171a;    /* Elevated cards and sidebar */
-  --color-card-elevated: #1a1d23; /* Settings cards, dropdowns */
-  --color-surface: #222328;      /* Lighter hover states */
-  --color-surface-hover: #2a2b30; /* Even lighter hover states */
-  --color-input-bg: rgba(0, 0, 0, 0.2); /* Darker input background */
-  --color-border: rgba(255, 255, 255, 0.05);
-  --color-border-hover: rgba(255, 255, 255, 0.1);
+  --color-primary: #007AFF;
+  --color-primary-hover: #0056CC;
+  --color-accent: #5856D6;
+  --color-brand-teal: #00A896;
+  --color-brand-teal-hover: #008577;
+  
+  --color-bg-dark: #000000;
+  --color-card-dark: #1C1C1E;
+  --color-card-elevated: #2C2C2E;
+  --color-surface: #3A3A3C;
+  --color-surface-hover: #48484A;
+  --color-input-bg: rgba(255, 255, 255, 0.08);
+  --color-border: rgba(255, 255, 255, 0.1);
+  --color-border-hover: rgba(255, 255, 255, 0.2);
 
-  /* Gradient for Co-Worker Hub typography */
-  --gradient-text: linear-gradient(135deg, #00f2fe 0%, #4facfe 50%, #8b5cf6 100%);
+  /* Gradient - Apple-style, refined, minimal */
+  --gradient-text: linear-gradient(135deg, #007AFF 0%, #5856D6 100%);
+  --gradient-card: linear-gradient(180deg, rgba(255,255,255,0.05) 0%, transparent 100%);
 
   /* Text */
   --color-text-primary: rgba(255, 255, 255, 0.9);
-  --color-text-secondary: rgba(255, 255, 255, 0.6);
-  --color-text-muted: rgba(255, 255, 255, 0.4);
-  --color-text-dim: rgba(255, 255, 255, 0.2);
+  --color-text-secondary: rgba(255, 255, 255, 0.7);
+  --color-text-muted: rgba(255, 255, 255, 0.5);
+  --color-text-dim: rgba(255, 255, 255, 0.3);
 
   /* Status & Agents */
-  --color-success: #22c55e;
-  --color-warning: #facc15;
-  --color-error: #ef4444;
-  --color-agent-fs: #a855f7;
-  --color-agent-mcp: #3b82f6;
-  --color-agent-default: #6b7280;
+  --color-success: #30D158;
+  --color-warning: #FFD60A;
+  --color-error: #FF453A;
+  --color-agent-fs: #BF5AF2;
+  --color-agent-mcp: #0A84FF;
+  --color-agent-default: #8E8E93;
+
+  /* ── Apple Glassmorphism ───────────────────────────────────────── */
+  --glass-bg: rgba(28, 28, 30, 0.8);
+  --glass-bg-hover: rgba(44, 44, 46, 0.9);
+  --glass-blur: 20px;
+  --glass-blur-heavy: 40px;
+  --glass-border: rgba(255, 255, 255, 0.1);
+  --glass-border-hover: rgba(255, 255, 255, 0.15);
+  --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  --glass-shadow-subtle: 0 2px 8px rgba(0, 0, 0, 0.2);
 
   /* ── ToolCallList tokens ───────────────────────────────────────── */
-  --color-tool-bg: #16171a;
-  --color-tool-border: rgba(255, 255, 255, 0.06);
-  --color-tool-text: rgba(255, 255, 255, 0.85);
-  --color-tool-text-muted: rgba(255, 255, 255, 0.45);
-  --color-tool-text-dim: rgba(255, 255, 255, 0.25);
-  --color-tool-finding-bg: rgba(0, 0, 0, 0.2);
-  --color-tool-finding-border: rgba(255, 255, 255, 0.05);
-  --color-tool-badge-bg: rgba(255, 255, 255, 0.05);
-  --color-tool-chip-bg: rgba(255, 255, 255, 0.04);
+  --color-tool-bg: #1C1C1E;
+  --color-tool-border: rgba(255, 255, 255, 0.08);
+  --color-tool-text: rgba(255, 255, 255, 0.9);
+  --color-tool-text-muted: rgba(255, 255, 255, 0.5);
+  --color-tool-text-dim: rgba(255, 255, 255, 0.3);
+  --color-tool-finding-bg: rgba(0, 0, 0, 0.3);
+  --color-tool-finding-border: rgba(255, 255, 255, 0.1);
+  --color-tool-badge-bg: rgba(255, 255, 255, 0.08);
+  --color-tool-chip-bg: rgba(255, 255, 255, 0.06);
 
-  /* Scrollbar */
-  --color-scrollbar-thumb: rgba(255, 255, 255, 0.15);
-  --color-scrollbar-thumb-hover: rgba(255, 255, 255, 0.25);
+  /* ── Scrollbar ─────────────────────────────────────────────────── */
+  --color-scrollbar-thumb: rgba(255, 255, 255, 0.2);
+  --color-scrollbar-thumb-hover: rgba(255, 255, 255, 0.3);
 
   /* ── Radii ─────────────────────────────────────────────────────── */
-  --radius-bubble: 1rem;
-  --radius-button: 0.5rem;
-  --radius-avatar: 0.5rem;
-  --radius-card: 0.75rem;
-  --radius-input: 1.5rem;
-  --radius-tile: 1.25rem;
+  --radius-none: 0;
+  --radius-xs: 4px;
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 20px;
+  --radius-2xl: 24px;
+  --radius-full: 9999px;
+  
+  --radius-bubble: 20px;
+  --radius-button: 10px;
+  --radius-avatar: 10px;
+  --radius-card: 16px;
+  --radius-input: 12px;
+  --radius-tile: 16px;
   --radius-pill: 9999px;
 
-  /* ── Spacing ────────────────────────────────────────────────────── */
-  --space-message-gap: 0.75rem;
-  --space-bubble-px: 1rem;
-  --space-bubble-py: 0.75rem;
+  /* ── Spacing (8pt grid) ─────────────────────────────────────────── */
+  --space-0: 0;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+  
+  --space-message-gap: 8px;
+  --space-bubble-px: 16px;
+  --space-bubble-py: 12px;
 
-  /* ── Typography ─────────────────────────────────────────────────── */
-  --font-size-message: 0.875rem;
-  --font-size-meta: 0.625rem;
-  --font-size-tool: 0.75rem;
-  --font-size-label: 0.6875rem;
+  /* ── Typography ───────────────────────────────────────────────── */
+  /* Font Family */
+  --font-family-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-family-mono: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+  
+  /* Font Sizes (iOS-style) */
+  --text-xs: 11px;
+  --text-sm: 13px;
+  --text-base: 15px;
+  --text-lg: 17px;
+  --text-xl: 20px;
+  --text-2xl: 22px;
+  --text-3xl: 28px;
+  --text-4xl: 34px;
+  
+  /* Legacy tokens */
+  --font-size-message: 15px;
+  --font-size-meta: 11px;
+  --font-size-tool: 13px;
+  --font-size-label: 12px;
+  
+  /* Font Weights */
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+  
+  /* Line Heights */
+  --leading-tight: 1.2;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.75;
 
-  /* ── Animation ──────────────────────────────────────────────────── */
+  /* ── Animation ─────────────────────────────────────────────────── */
+  --duration-instant: 0ms;
   --duration-fast: 150ms;
-  --duration-normal: 300ms;
-  --duration-slow: 500ms;
-  --ease-out: cubic-bezier(0, 0, 0.2, 1);
+  --duration-normal: 250ms;
+  --duration-slow: 400ms;
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
+  --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
 
-  /* ── Shadows ────────────────────────────────────────────────────── */
-  --shadow-glass: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+  /* ── Badge Tokens ───────────────────────────────────────────────── */
+  --badge-padding-x: 8px;
+  --badge-padding-y: 2px;
+  --badge-font-size: 11px;
+  --badge-font-weight: 500;
+  --badge-radius: 9999px;
+  
+  --badge-success-bg: rgba(48, 209, 88, 0.15);
+  --badge-success-text: var(--color-success);
+  --badge-success-border: rgba(48, 209, 88, 0.3);
+  
+  --badge-warning-bg: rgba(255, 214, 10, 0.15);
+  --badge-warning-text: var(--color-warning);
+  --badge-warning-border: rgba(255, 214, 10, 0.3);
+  
+  --badge-error-bg: rgba(255, 69, 58, 0.15);
+  --badge-error-text: var(--color-error);
+  --badge-error-border: rgba(255, 69, 58, 0.3);
+  
+  --badge-idle-bg: var(--color-surface);
+  --badge-idle-text: var(--color-text-muted);
+  --badge-idle-border: var(--color-border);
+  
+  --badge-active-bg: rgba(0, 122, 255, 0.15);
+  --badge-active-text: var(--color-primary);
+  --badge-active-border: rgba(0, 122, 255, 0.3);
+
+  /* ── Shadows ───────────────────────────────────────────────────── */
+  --shadow-none: none;
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.1);
+  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.1);
+  --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.15);
+  --shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.2);
+  --shadow-xl: 0 16px 32px rgba(0, 0, 0, 0.25);
+  
+  --shadow-glass: 0 8px 32px rgba(0, 0, 0, 0.3);
   --shadow-top: 0 -10px 20px rgba(0, 0, 0, 0.2);
+  --shadow-glow: 0 0 20px rgba(0, 122, 255, 0.3);
+
+  /* ── Button Tokens ─────────────────────────────────────────────── */
+  --button-height-sm: 32px;
+  --button-height-md: 40px;
+  --button-height-lg: 50px;
+  --button-padding-x-sm: 12px;
+  --button-padding-x-md: 16px;
+  --button-padding-x-lg: 24px;
+  --button-font-weight: 500;
+
+  /* ── Card Tokens ───────────────────────────────────────────────── */
+  --card-radius: var(--radius-card);
+  --card-padding-sm: var(--space-3);
+  --card-padding-md: var(--space-4);
+  --card-padding-lg: var(--space-6);
+  --card-default-bg: var(--color-card-dark);
+  --card-default-border: var(--color-border);
+  --card-elevated-bg: var(--color-card-elevated);
+  --card-elevated-shadow: var(--shadow-md);
+  --card-glass-bg: var(--glass-bg);
+  --card-glass-border: var(--glass-border);
+  --card-glass-shadow: var(--glass-shadow);
+  --card-outlined-border: var(--color-border);
+  
+  /* ── Component Variants ─────────────────────────────────────────── */
+  /* StatusDot */
+  --status-dot-sm: 6px;
+  --status-dot-md: 8px;
+  --status-dot-lg: 12px;
+  
+  /* StatusDot glow shadows */
+  --status-glow-success: 0 0 8px var(--color-success);
+  --status-glow-warning: 0 0 8px var(--color-warning);
+  --status-glow-error: 0 0 8px var(--color-error);
+  --status-glow-active: 0 0 8px var(--color-primary);
+
+  /* ── Input Tokens ─────────────────────────────────────────────── */
+  --input-height: 44px;
+  --input-padding-x: 16px;
+  --input-padding-y: 12px;
 }
 
 /* ── Light Theme ─────────────────────────────────────────────────── */
 [data-theme="light"] {
-  --color-primary: #2563eb;
-  --color-primary-hover: #1d4ed8;
-  --color-accent: #3b82f6;
-  --color-brand-teal: #0d9488;
-  --color-bg-dark: #f1f5f9;      /* Tailwind slate-100 backgound to reduce glare */
-  --color-card-dark: #ffffff;    /* Pure white for sidebar and elevated areas */
-  --color-card-elevated: #ffffff; /* Same for settings cards */
-  --color-surface: #ffffff;      /* Pure white for tiles and inputs */
-  --color-surface-hover: #f8fafc; /* Very subtle gray for hover states */
-  --color-input-bg: #ffffff;     /* White for inputs so they don't look disabled */
-  --color-border: #e2e8f0;       /* Solid border color */
-  --color-border-hover: #cbd5e1; /* Darker solid border on hover */
+  --color-primary: #007AFF;
+  --color-primary-hover: #0056CC;
+  --color-accent: #5856D6;
+  --color-brand-teal: #0D9488;
+  --color-brand-teal-hover: #0F766E;
+  
+  --color-bg-dark: #F5F5F7;
+  --color-card-dark: #FFFFFF;
+  --color-card-elevated: #FFFFFF;
+  --color-surface: #F5F5F7;
+  --color-surface-hover: #E8E8ED;
+  --color-input-bg: rgba(0, 0, 0, 0.04);
+  --color-border: rgba(0, 0, 0, 0.1);
+  --color-border-hover: rgba(0, 0, 0, 0.2);
 
-  --gradient-text: linear-gradient(135deg, #0d9488 0%, #2563eb 50%, #7c3aed 100%);
+  --gradient-text: linear-gradient(135deg, #007AFF 0%, #5856D6 100%);
+  --gradient-card: linear-gradient(180deg, rgba(255,255,255,1) 0%, rgba(245,245,247,1) 100%);
 
-  /* Text - Much higher contrast */
-  --color-text-primary: #0f172a;   /* Near black for primary text */
-  --color-text-secondary: #334155; /* Dark gray for secondary text */
-  --color-text-muted: #64748b;     /* Medium gray for muted text */
-  --color-text-dim: #94a3b8;       /* Lighter gray for dim text */
+  /* Text - High contrast */
+  --color-text-primary: #1D1D1F;
+  --color-text-secondary: #424245;
+  --color-text-muted: #6E6E73;
+  --color-text-dim: #A1A1A6;
 
-  /* Status & Agents */
-  --color-success: #16a34a;
-  --color-warning: #ea580c;
-  --color-error: #dc2626;
-  --color-agent-fs: #9333ea;    /* Slightly deeper purple for light mode */
-  --color-agent-mcp: #2563eb;   /* Deeper blue for light mode */
-  --color-agent-default: #64748b; /* Slate-500 for light mode */
+  /* Status */
+  --color-success: #34C759;
+  --color-warning: #FF9F0A;
+  --color-error: #FF3B30;
+  --color-agent-fs: #AF52DE;
+  --color-agent-mcp: #007AFF;
+  --color-agent-default: #8E8E93;
 
-  /* ── ToolCallList tokens ─────────────────────────────────────── */
-  --color-tool-bg: #ffffff;
-  --color-tool-border: #e2e8f0;
-  --color-tool-text: #1e293b;
-  --color-tool-text-muted: #64748b;
-  --color-tool-text-dim: #94a3b8;
-  --color-tool-finding-bg: #f8fafc;
-  --color-tool-finding-border: #e2e8f0;
-  --color-tool-badge-bg: #f1f5f9;
-  --color-tool-chip-bg: #f1f5f9;
+  /* ── ToolCallList ───────────────────────────────────────────── */
+  --color-tool-bg: #FFFFFF;
+  --color-tool-border: rgba(0, 0, 0, 0.08);
+  --color-tool-text: #1D1D1F;
+  --color-tool-text-muted: #6E6E73;
+  --color-tool-text-dim: #A1A1A6;
+  --color-tool-finding-bg: rgba(0, 0, 0, 0.02);
+  --color-tool-finding-border: rgba(0, 0, 0, 0.06);
+  --color-tool-badge-bg: rgba(0, 0, 0, 0.04);
+  --color-tool-chip-bg: rgba(0, 0, 0, 0.03);
 
-  /* Scrollbar */
-  --color-scrollbar-thumb: #cbd5e1;
-  --color-scrollbar-thumb-hover: #94a3b8;
+  /* ── Scrollbar ───────────────────────────────────────────────── */
+  --color-scrollbar-thumb: rgba(0, 0, 0, 0.2);
+  --color-scrollbar-thumb-hover: rgba(0, 0, 0, 0.35);
 
-  /* Shadows — Softer on light backgrounds */
-  --shadow-glass: 0 4px 12px 0 rgba(0, 0, 0, 0.05);
-  --shadow-top: 0 -10px 20px rgba(0, 0, 0, 0.03);
+  /* ── Glassmorphism ───────────────────────────────────────────── */
+  --glass-bg: rgba(255, 255, 255, 0.8);
+  --glass-bg-hover: rgba(255, 255, 255, 0.9);
+  --glass-border: rgba(0, 0, 0, 0.1);
+  --glass-border-hover: rgba(0, 0, 0, 0.15);
+  --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.08);
+
+  /* ── Badge Tokens ───────────────────────────────────────────── */
+  --badge-success-bg: rgba(52, 199, 89, 0.15);
+  --badge-success-text: var(--color-success);
+  --badge-success-border: rgba(52, 199, 89, 0.3);
+  
+  --badge-warning-bg: rgba(255, 159, 10, 0.15);
+  --badge-warning-text: var(--color-warning);
+  --badge-warning-border: rgba(255, 159, 10, 0.3);
+  
+  --badge-error-bg: rgba(255, 59, 48, 0.15);
+  --badge-error-text: var(--color-error);
+  --badge-error-border: rgba(255, 59, 48, 0.3);
+  
+  --badge-idle-bg: var(--color-surface);
+  --badge-idle-text: var(--color-text-muted);
+  --badge-idle-border: var(--color-border);
+  
+  --badge-active-bg: rgba(0, 122, 255, 0.15);
+  --badge-active-text: var(--color-primary);
+  --badge-active-border: rgba(0, 122, 255, 0.3);
+
+  /* ── Card Tokens ───────────────────────────────────────────────── */
+  --card-default-bg: var(--color-card-dark);
+  --card-default-border: var(--color-border);
+  --card-elevated-bg: var(--color-card-elevated);
+  --card-elevated-shadow: var(--shadow-md);
+  --card-glass-bg: var(--glass-bg);
+  --card-glass-border: var(--glass-border);
+  --card-glass-shadow: var(--glass-shadow);
+  --card-outlined-border: var(--color-border);
+
+  /* ── Button Tokens ─────────────────────────────────────────────── */
+  --button-primary-bg: var(--color-primary);
+  --button-primary-text: white;
+  --button-primary-hover: var(--color-primary-hover);
+  
+  --button-secondary-bg: var(--color-surface);
+  --button-secondary-text: var(--color-text-primary);
+  --button-secondary-border: var(--color-border);
+  --button-secondary-hover: var(--color-surface-hover);
+  
+  --button-ghost-bg: transparent;
+  --button-ghost-text: var(--color-text-secondary);
+  --button-ghost-hover-bg: var(--color-surface);
+  --button-ghost-hover-text: var(--color-text-primary);
+  
+  --button-danger-bg: var(--color-error);
+  --button-danger-text: white;
+  
+  --button-glass-bg: var(--glass-bg);
+  --button-glass-text: var(--color-text-primary);
+  --button-glass-border: var(--glass-border);
+  --button-glass-hover-bg: var(--glass-bg-hover);
+  --button-glass-hover-border: var(--glass-border-hover);
 }
+
+/* ═══════════════════════════════════════════════════════════════ */
+/* ── Component Classes ────────────────────────────────────────── */
+/* ═══════════════════════════════════════════════════════════════ */
+
+/* StatusDot */
+.status-dot {
+  display: inline-block;
+  border-radius: 9999px;
+}
+.status-dot-sm { width: var(--status-dot-sm); height: var(--status-dot-sm); }
+.status-dot-md { width: var(--status-dot-md); height: var(--status-dot-md); }
+.status-dot-lg { width: var(--status-dot-lg); height: var(--status-dot-lg); }
+
+.status-dot-success { background-color: var(--color-success); }
+.status-dot-warning { background-color: var(--color-warning); }
+.status-dot-error { background-color: var(--color-error); }
+.status-dot-idle { background-color: var(--color-text-dim); }
+.status-dot-active { background-color: var(--color-primary); }
+
+.status-dot-animated.status-dot-success { box-shadow: var(--status-glow-success); }
+.status-dot-animated.status-dot-warning { box-shadow: var(--status-glow-warning); }
+.status-dot-animated.status-dot-error { box-shadow: var(--status-glow-error); }
+.status-dot-animated.status-dot-active { box-shadow: var(--status-glow-active); }
+
+/* StatusBadge */
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: var(--badge-padding-y) var(--badge-padding-x);
+  border-radius: var(--badge-radius);
+  font-size: var(--badge-font-size);
+  font-weight: var(--badge-font-weight);
+  border: 1px solid;
+}
+
+.status-badge-success { background-color: var(--badge-success-bg); color: var(--badge-success-text); border-color: var(--badge-success-border); }
+.status-badge-warning { background-color: var(--badge-warning-bg); color: var(--badge-warning-text); border-color: var(--badge-warning-border); }
+.status-badge-error { background-color: var(--badge-error-bg); color: var(--badge-error-text); border-color: var(--badge-error-border); }
+.status-badge-idle { background-color: var(--badge-idle-bg); color: var(--badge-idle-text); border-color: var(--badge-idle-border); }
+.status-badge-active { background-color: var(--badge-active-bg); color: var(--badge-active-text); border-color: var(--badge-active-border); }
+
+/* Card */
+.card {
+  border-radius: var(--card-radius);
+  transition: all duration-[var(--duration-normal)] ease-[var(--ease-out)];
+}
+.card-default { background-color: var(--card-default-bg); border: 1px solid var(--card-default-border); }
+.card-elevated { background-color: var(--card-elevated-bg); border: 1px solid var(--card-default-border); box-shadow: var(--card-elevated-shadow); }
+.card-glass { background-color: var(--card-glass-bg); border: 1px solid var(--card-glass-border); box-shadow: var(--card-glass-shadow); backdrop-filter: blur(var(--glass-blur)); }
+.card-outlined { background-color: transparent; border: 1px solid var(--card-outlined-border); }
+
+.card-padding-none { padding: 0; }
+.card-padding-sm { padding: var(--card-padding-sm); }
+.card-padding-md { padding: var(--card-padding-md); }
+.card-padding-lg { padding: var(--card-padding-lg); }
+
+.card-hoverable:hover { border-color: var(--color-border-hover); box-shadow: var(--shadow-lg); cursor: pointer; }
+
+/* Card sections */
+.card-header { padding-bottom: var(--space-3); border-bottom: 1px solid var(--color-border); margin-bottom: var(--space-4); }
+.card-title { font-size: var(--text-lg); font-weight: var(--font-weight-semibold); color: var(--color-text-primary); }
+.card-description { font-size: var(--text-sm); color: var(--color-text-muted); margin-top: var(--space-1); }
+.card-footer { padding-top: var(--space-3); margin-top: var(--space-4); border-top: 1px solid var(--color-border); }
+
+/* Button */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--button-radius);
+  font-weight: var(--button-font-weight);
+  transition: all duration-[var(--duration-fast)] ease-[var(--ease-out)];
+  cursor: pointer;
+  border: none;
+}
+.btn:focus-visible { outline: none; box-shadow: 0 0 0 2px var(--color-bg-dark), 0 0 0 4px var(--color-primary); }
+.btn:disabled { opacity: 0.4; pointer-events: none; cursor: not-allowed; }
+
+/* Button sizes */
+.btn-sm { height: var(--button-height-sm); padding-left: var(--button-padding-x-sm); padding-right: var(--button-padding-x-sm); font-size: 13px; gap: 6px; }
+.btn-md { height: var(--button-height-md); padding-left: var(--button-padding-x-md); padding-right: var(--button-padding-x-md); font-size: 15px; gap: 8px; }
+.btn-lg { height: var(--button-height-lg); padding-left: var(--button-padding-x-lg); padding-right: var(--button-padding-x-lg); font-size: 17px; gap: 8px; }
+
+/* Button variants */
+.btn-primary { background-color: var(--button-primary-bg); color: var(--button-primary-text); }
+.btn-primary:hover { background-color: var(--button-primary-hover); }
+.btn-primary:active { transform: scale(0.98); }
+
+.btn-secondary { background-color: var(--button-secondary-bg); color: var(--button-secondary-text); border: 1px solid var(--button-secondary-border); }
+.btn-secondary:hover { background-color: var(--button-secondary-hover); }
+.btn-secondary:active { transform: scale(0.98); }
+
+.btn-ghost { background-color: var(--button-ghost-bg); color: var(--button-ghost-text); }
+.btn-ghost:hover { background-color: var(--button-ghost-hover-bg); color: var(--button-ghost-hover-text); }
+.btn-ghost:active { transform: scale(0.98); }
+
+.btn-danger { background-color: var(--button-danger-bg); color: var(--button-danger-text); }
+.btn-danger:hover { opacity: 0.9; }
+.btn-danger:active { transform: scale(0.98); }
+
+.btn-glass { background-color: var(--button-glass-bg); color: var(--button-glass-text); border: 1px solid var(--button-glass-border); backdrop-filter: blur(var(--glass-blur)); }
+.btn-glass:hover { background-color: var(--button-glass-hover-bg); border-color: var(--button-glass-hover-border); }
+.btn-glass:active { transform: scale(0.98); }
+
+.btn-full-width { width: 100%; }

--- a/src/renderer/src/styles/design-tokens.css
+++ b/src/renderer/src/styles/design-tokens.css
@@ -16,7 +16,7 @@
   /* ── Colors ──────────────────────────────────────────────────────── */
   --color-primary: #007AFF;
   --color-primary-hover: #0056CC;
-  --color-accent: #5856D6;
+  --color-accent: #00A896;
   --color-brand-teal: #00A896;
   --color-brand-teal-hover: #008577;
   
@@ -30,7 +30,7 @@
   --color-border-hover: rgba(255, 255, 255, 0.2);
 
   /* Gradient - Apple-style, refined, minimal */
-  --gradient-text: linear-gradient(135deg, #007AFF 0%, #5856D6 100%);
+  --gradient-text: linear-gradient(135deg, #007AFF 0%, #00A896 100%);
   --gradient-card: linear-gradient(180deg, rgba(255,255,255,0.05) 0%, transparent 100%);
 
   /* Text */
@@ -124,9 +124,9 @@
   --space-bubble-py: 12px;
 
   /* ── Typography ───────────────────────────────────────────────── */
-  /* Font Family */
-  --font-family-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --font-family-mono: 'SF Mono', 'Fira Code', 'JetBrains Mono', monospace;
+  /* Font Family - Apple system fonts */
+  --font-family-sans: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'SF Pro Text', 'Helvetica Neue', 'Inter', sans-serif;
+  --font-family-mono: 'SF Mono', 'Fira Code', 'JetBrains Mono', Menlo, Monaco, monospace;
   
   /* Font Sizes (iOS-style) */
   --text-xs: 11px;
@@ -248,7 +248,7 @@
 [data-theme="light"] {
   --color-primary: #007AFF;
   --color-primary-hover: #0056CC;
-  --color-accent: #5856D6;
+  --color-accent: #0D9488;
   --color-brand-teal: #0D9488;
   --color-brand-teal-hover: #0F766E;
   
@@ -261,7 +261,7 @@
   --color-border: rgba(0, 0, 0, 0.1);
   --color-border-hover: rgba(0, 0, 0, 0.2);
 
-  --gradient-text: linear-gradient(135deg, #007AFF 0%, #5856D6 100%);
+  --gradient-text: linear-gradient(135deg, #007AFF 0%, #0D9488 100%);
   --gradient-card: linear-gradient(180deg, rgba(255,255,255,1) 0%, rgba(245,245,247,1) 100%);
 
   /* Text - High contrast */

--- a/src/renderer/src/styles/design-tokens.css
+++ b/src/renderer/src/styles/design-tokens.css
@@ -47,6 +47,22 @@
   --color-agent-mcp: #0A84FF;
   --color-agent-default: #8E8E93;
 
+  /* ── Extended Status Colors ──────────────────────────────────────── */
+  /* Status backgrounds (translucent versions for cards/badges) */
+  --color-success-bg: rgba(48, 209, 88, 0.15);
+  --color-warning-bg: rgba(255, 214, 10, 0.15);
+  --color-error-bg: rgba(255, 69, 58, 0.15);
+  --color-primary-bg: rgba(0, 122, 255, 0.15);
+  --color-accent-bg: rgba(88, 86, 214, 0.15);
+  
+  /* Inverse colors (for dark backgrounds) */
+  --color-text-inverse: #FFFFFF;
+  --color-text-inverse-muted: rgba(255, 255, 255, 0.7);
+  
+  /* Subtle backgrounds */
+  --color-bg-subtle: rgba(255, 255, 255, 0.03);
+  --color-bg-subtle-hover: rgba(255, 255, 255, 0.06);
+
   /* ── Apple Glassmorphism ───────────────────────────────────────── */
   --glass-bg: rgba(28, 28, 30, 0.8);
   --glass-bg-hover: rgba(44, 44, 46, 0.9);
@@ -262,6 +278,19 @@
   --color-agent-mcp: #007AFF;
   --color-agent-default: #8E8E93;
 
+  /* Extended Status Colors */
+  --color-success-bg: rgba(52, 199, 89, 0.15);
+  --color-warning-bg: rgba(255, 159, 10, 0.15);
+  --color-error-bg: rgba(255, 59, 48, 0.15);
+  --color-primary-bg: rgba(0, 122, 255, 0.15);
+  --color-accent-bg: rgba(88, 86, 214, 0.15);
+  
+  --color-text-inverse: #FFFFFF;
+  --color-text-inverse-muted: rgba(255, 255, 255, 0.7);
+  
+  --color-bg-subtle: rgba(0, 0, 0, 0.02);
+  --color-bg-subtle-hover: rgba(0, 0, 0, 0.05);
+
   /* ── ToolCallList ───────────────────────────────────────────── */
   --color-tool-bg: #FFFFFF;
   --color-tool-border: rgba(0, 0, 0, 0.08);
@@ -446,3 +475,36 @@
 .btn-glass:active { transform: scale(0.98); }
 
 .btn-full-width { width: 100%; }
+
+/* Status background utilities */
+.bg-success { background-color: var(--color-success-bg); }
+.bg-warning { background-color: var(--color-warning-bg); }
+.bg-error { background-color: var(--color-error-bg); }
+.bg-primary { background-color: var(--color-primary-bg); }
+.bg-accent { background-color: var(--color-accent-bg); }
+
+.text-success { color: var(--color-success); }
+.text-warning { color: var(--color-warning); }
+.text-error { color: var(--color-error); }
+.text-primary { color: var(--color-primary); }
+.text-accent { color: var(--color-accent); }
+
+.border-success { border-color: var(--color-success); }
+.border-warning { border-color: var(--color-warning); }
+.border-error { border-color: var(--color-error); }
+.border-primary { border-color: var(--color-primary); }
+.border-accent { border-color: var(--color-accent); }
+
+/* Hover states */
+.hover\:bg-success:hover { background-color: var(--color-success-bg); }
+.hover\:bg-error:hover { background-color: var(--color-error-bg); }
+.hover\:text-success:hover { color: var(--color-success); }
+.hover\:text-error:hover { color: var(--color-error); }
+
+/* Text inverse (for dark backgrounds) */
+.text-inverse { color: var(--color-text-inverse); }
+.text-inverse-muted { color: var(--color-text-inverse-muted); }
+
+/* Subtle backgrounds */
+.bg-subtle { background-color: var(--color-bg-subtle); }
+.bg-subtle-hover { background-color: var(--color-bg-subtle-hover); }


### PR DESCRIPTION
## Summary

Complete design system overhaul to create a professional, non-"AI slop" aesthetic with Apple-style design tokens.

### Changes

- **Design Tokens**: Comprehensive token system in `design-tokens.css` with:
  - Apple-inspired color palette (blue #007AFF, teal #00A896)
  - Glassmorphism tokens for subtle blur effects
  - Full dark/light theme compatibility
  - 8pt spacing grid
  - Typography scale (iOS-style sizes)

- **New Components**:
  - `Button.tsx` - 5 variants (primary, secondary, ghost, danger, glass) via CSS-only classes
  - `Card.tsx` - 4 variants (default, elevated, glass, outlined) via CSS-only classes
  - Updated `StatusDot.tsx` with glow instead of pulse animations

### Fixes

- **AI Slop Removed**:
  - Replaced cyan-blue gradient text with solid colors
  - Replaced all `animate-pulse` with subtle glow effects
  - Removed harsh colors (emerald, purple) in favor of brand tokens

- **Dark Theme Optimizations**:
  - Fixed toggle switch (softer colors, subtle glow)
  - Fixed hardcoded hex colors in sidebar
  - Improved text contrast

### Components Migrated

- ChatInput, MessageBubble, ToolCallList, EmptyState
- VoiceButton, InputToolbar, AttachmentBar, SendButton
- McpServerCard, Header, Sidebar
- And more...

### Testing

- TypeScript: ✅ Pass
- ESLint: ✅ Pass (warnings only)