### PR TITLE
Fix file-write approval workflow, path safety, and session-scoped controls

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -297,6 +297,14 @@ The chat store manages multiple independent sessions concurrently. The key desig
 
 The chat store uses a custom **1-second debounced storage adapter** to prevent UI thread blocking. During agent tool loops, `addMessage`/`updateMessage` fire rapidly (every tool call), and each would ordinarily trigger `JSON.stringify` + `localStorage.setItem` of ALL sessions. The adapter coalesces writes to at most once per second, dramatically reducing main-thread jank during heavy tool execution.
 
+**Session-Scoped File Write Approval:**
+
+- Each `ChatSession` now stores its own `fileWriteAutoApprove` boolean.
+- The input toolbar (next to workspace selection) exposes this as a visible per-session toggle (`Auto File Write Approval: ON/OFF`).
+- Runtime injects `_sessionId` + `_sessionAutoApprove` into `fs_*` tool calls.
+- `FileSystemService` stages or writes based on that session flag (with global setting as fallback), and pending review queries are session-filtered.
+- Internal task-plan/execution files are persisted under AI-Worker's hidden system workspace (`~/.ai-worker/system-workspace/...`) and always bypass staged approvals.
+
 > [!NOTE]
 > Storage key bumped from `ai-worker-chat-v2` → `ai-worker-chat-v3`.
 > Old persisted flat fields (`isProcessing`, `abortController`) no longer exist in the state shape.

--- a/new-issues.md
+++ b/new-issues.md
@@ -42,6 +42,17 @@ This log contains the issues tracked during end-to-end testing of the AI Worker 
 - Memory appears unreliable even when backend/runtime recall succeeds.
 - Creates confusion and repeat prompts, increasing latency and token usage.
 
+## 31. Real E2E Harness Can Hard-Fail on Closed Window During Screenshot Capture
+**Observed Behavior:**
+- In live `real_e2e_test` runs under heavy 429/retry pressure, the harness can detect window closure mid-wait and then still attempt `page.screenshot`, causing a hard failure:
+  - `Target page, context or browser has been closed`
+  - Failure occurs in `screenshot()` after timeout/closure path.
+
+**If Not Fixed (User Experience Impact):**
+- Live validation can fail for harness reasons even when product logic is otherwise functioning.
+- Re-run noise increases and obscures true regressions.
+- Release confidence drops when flaky harness failures look like product failures.
+
 ### Latest Validation Update (Apr 5, 2026, pre-push revalidation)
 - Completed checks:
   - `npm run -s typecheck` ✅

--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -1,4 +1,15 @@
 import { app, shell, ipcMain, dialog } from 'electron'
+import * as path from 'path'
+
+function normalizePathForCompare(value: string): string {
+    return path.resolve(value).replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
+}
+
+function isPathWithin(rootPath: string, targetPath: string): boolean {
+    const normalizedRoot = normalizePathForCompare(rootPath)
+    const normalizedTarget = normalizePathForCompare(targetPath)
+    return normalizedTarget === normalizedRoot || normalizedTarget.startsWith(`${normalizedRoot}/`)
+}
 
 export function registerAppHandlers(): void {
     // Shell operations
@@ -9,15 +20,31 @@ export function registerAppHandlers(): void {
     // App info
     ipcMain.handle('app:get-version', () => app.getVersion())
     ipcMain.handle('app:get-name', () => app.getName())
+    ipcMain.handle('app:get-home-path', () => app.getPath('home'))
 
     // Folder selection
     ipcMain.handle('app:select-folder', async () => {
         const result = await dialog.showOpenDialog({
             properties: ['openDirectory'],
             title: 'Select Workspace Folder',
-            buttonLabel: 'Select Workspace'
+            buttonLabel: 'Select Workspace',
+            defaultPath: app.getPath('home'),
         })
-        return result.canceled ? null : result.filePaths[0]
+        if (result.canceled || result.filePaths.length === 0) return null
+        const selectedPath = result.filePaths[0]
+        const userHomePath = app.getPath('home')
+
+        if (!isPathWithin(userHomePath, selectedPath)) {
+            await dialog.showMessageBox({
+                type: 'warning',
+                title: 'Invalid Workspace Location',
+                message: 'Workspace must be inside your user home folder.',
+                detail: `Select a folder under: ${userHomePath}`,
+            })
+            return null
+        }
+
+        return selectedPath
     })
 
     // Dependencies

--- a/src/main/ipc/fs.ts
+++ b/src/main/ipc/fs.ts
@@ -2,13 +2,30 @@ import { ipcMain, app } from 'electron'
 import { FileSystemService } from '../services/FileSystemService'
 import * as path from 'path'
 import * as fs from 'fs/promises'
+import { createHash } from 'crypto'
+
+function getInternalTaskRoot(): string {
+    return path.join(app.getPath('home'), '.ai-worker', 'system-workspace')
+}
+
+function getInternalWorkspaceScope(workspacePath: string | undefined | null): string {
+    const normalized = workspacePath && workspacePath.trim() !== ''
+        ? path.resolve(workspacePath)
+        : 'default-workspace'
+    const digest = createHash('sha256').update(normalized).digest('hex').slice(0, 16)
+    return digest
+}
+
+function getInternalWorkspaceDir(workspacePath: string | undefined | null): string {
+    return path.join(getInternalTaskRoot(), getInternalWorkspaceScope(workspacePath))
+}
 
 export function registerFsHandlers(): void {
     // Get pending changes for review
-    ipcMain.handle('fs:get-pending-changes', async () => {
+    ipcMain.handle('fs:get-pending-changes', async (_event, sessionId?: string) => {
         try {
             const fsService = FileSystemService.getInstance()
-            return fsService.getPendingChanges()
+            return fsService.getPendingChanges(sessionId || 'default')
         } catch (error) {
             console.error('Failed to get pending changes:', error)
             return []
@@ -42,13 +59,7 @@ export function registerFsHandlers(): void {
         try {
             if (!filename.match(/^[a-zA-Z0-9_.-]+$/)) throw new Error("Invalid filename");
 
-            // Fallback: If no workspace is selected, save to the app's user data directory (e.g. ~/Library/Application Support/ai-worker)
-            let internalDir: string;
-            if (workspacePath && workspacePath.trim() !== '') {
-                internalDir = path.join(workspacePath, '.ai-worker');
-            } else {
-                internalDir = path.join(app.getPath('userData'), 'tasks-fallback');
-            }
+            const internalDir = getInternalWorkspaceDir(workspacePath)
 
             const targetPath = path.join(internalDir, filename);
 
@@ -68,19 +79,26 @@ export function registerFsHandlers(): void {
         try {
             if (!filename.match(/^[a-zA-Z0-9_.-]+$/)) throw new Error("Invalid filename");
 
-            let internalDir: string;
-            if (workspacePath && workspacePath.trim() !== '') {
-                internalDir = path.join(workspacePath, '.ai-worker');
-            } else {
-                internalDir = path.join(app.getPath('userData'), 'tasks-fallback');
-            }
-
+            const internalDir = getInternalWorkspaceDir(workspacePath)
             const targetPath = path.join(internalDir, filename);
             const content = await fs.readFile(targetPath, 'utf8');
             return { success: true, content };
         } catch (error) {
-            // Silently fail if it doesn't exist yet
-            return { success: false, error: error instanceof Error ? error.message : String(error) };
+            // Legacy fallback for pre-migration files: workspace/.ai-worker and userData/tasks-fallback
+            try {
+                let legacyDir: string;
+                if (workspacePath && workspacePath.trim() !== '') {
+                    legacyDir = path.join(workspacePath, '.ai-worker');
+                } else {
+                    legacyDir = path.join(app.getPath('userData'), 'tasks-fallback');
+                }
+                const legacyPath = path.join(legacyDir, filename);
+                const content = await fs.readFile(legacyPath, 'utf8');
+                return { success: true, content };
+            } catch {
+                // Silently fail if it doesn't exist yet
+                return { success: false, error: error instanceof Error ? error.message : String(error) };
+            }
         }
     })
 

--- a/src/main/services/FileSystemService.ts
+++ b/src/main/services/FileSystemService.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs'
 import * as path from 'path'
 import { app } from 'electron'
 import { randomUUID } from 'crypto'
+import { Store } from '../lib/store-wrapper'
 
 // ============================================================================
 // TYPE DEFINITIONS
@@ -187,8 +188,11 @@ export class FileSystemService {
      */
     private async getSafeModeSettings(): Promise<{ safeMode: boolean; autoApprove: boolean }> {
         try {
-            const Store = (await import('electron-store')).default
-            const store = new Store<Record<string, any>>()
+            // Must use the same store namespace as ipc/store.ts and settingsStore.
+            const store = new Store<Record<string, any>>({
+                name: 'ai-worker-store',
+                defaults: {},
+            })
             const settings = ((store as any).get('mcpFileSystem', {}) as any) as SafeModeSettings
             return {
                 safeMode: settings.safeMode !== false, // Default to true

--- a/src/main/services/FileSystemService.ts
+++ b/src/main/services/FileSystemService.ts
@@ -47,6 +47,7 @@ interface ToolCallResponse {
  */
 interface SafeModeSettings {
     safeMode?: boolean
+    autoApprove?: boolean
 }
 
 // ============================================================================
@@ -184,16 +185,35 @@ export class FileSystemService {
      * Check if Safe Mode is enabled
      * @private
      */
-    private async isSafeModeEnabled(): Promise<boolean> {
+    private async getSafeModeSettings(): Promise<{ safeMode: boolean; autoApprove: boolean }> {
         try {
             const Store = (await import('electron-store')).default
             const store = new Store<Record<string, any>>()
             const settings = ((store as any).get('mcpFileSystem', {}) as any) as SafeModeSettings
-            return settings.safeMode !== false  // Default to true
+            return {
+                safeMode: settings.safeMode !== false, // Default to true
+                autoApprove: settings.autoApprove === true, // Default to false
+            }
         } catch (error) {
             console.warn('[FileSystemService] Failed to check safe mode, defaulting to enabled:', error)
-            return true  // Fail-safe to protect user files
+            return {
+                safeMode: true, // Fail-safe to protect user files
+                autoApprove: false,
+            }
         }
+    }
+
+    /**
+     * Internal tracking files are written by the app itself and should not
+     * require staged user approval even when Safe Mode is enabled.
+     */
+    private isInternalTrackingFile(filePath: string): boolean {
+        const normalized = path.normalize(filePath)
+        const parentDir = path.basename(path.dirname(normalized)).toLowerCase()
+        const fileName = path.basename(normalized).toLowerCase()
+
+        if (parentDir !== '.ai-worker') return false
+        return fileName === 'tasks.json' || fileName === 'execution-plan.json'
     }
 
     // ========================================================================
@@ -313,9 +333,10 @@ export class FileSystemService {
         try {
             switch (name) {
                 case 'fs_write_file': {
-                    const isSafeMode = await this.isSafeModeEnabled()
+                    const { safeMode: isSafeMode, autoApprove } = await this.getSafeModeSettings()
+                    const isInternalTrackingWrite = this.isInternalTrackingFile(args.path)
 
-                    if (isSafeMode) {
+                    if (isSafeMode && !autoApprove && !isInternalTrackingWrite) {
                         // Safe Mode: Stage for user review
                         const change = await this.stageWrite(args.path, args.content)
                         return {
@@ -326,14 +347,26 @@ export class FileSystemService {
                             }
                         }
                     } else {
-                        // Direct write (Safe Mode disabled)
+                        // Direct write:
+                        // - Safe Mode disabled OR
+                        // - Auto-approve enabled OR
+                        // - Internal tracking file
                         await fs.mkdir(path.dirname(args.path), { recursive: true })
                         await fs.writeFile(args.path, args.content, 'utf8')
+                        const status = isInternalTrackingWrite
+                            ? 'written_internal'
+                            : autoApprove
+                                ? 'written_auto_approved'
+                                : 'written'
                         return {
                             result: {
-                                status: 'written',
+                                status,
                                 path: args.path,
-                                message: `File written to ${args.path}`
+                                message: isInternalTrackingWrite
+                                    ? `Internal tracking file updated: ${args.path}`
+                                    : autoApprove
+                                        ? `File written with auto-approval: ${args.path}`
+                                    : `File written to ${args.path}`
                             }
                         }
                     }

--- a/src/main/services/FileSystemService.ts
+++ b/src/main/services/FileSystemService.ts
@@ -183,6 +183,33 @@ export class FileSystemService {
     }
 
     /**
+     * Remove a change ID from all session index lists.
+     * Prevents stale session references from accumulating indefinitely.
+     */
+    private removeChangeFromSessions(changeId: string): void {
+        for (const [sessionId, ids] of this.sessionChanges.entries()) {
+            const next = ids.filter(id => id !== changeId)
+            if (next.length > 0) {
+                this.sessionChanges.set(sessionId, next)
+            } else {
+                this.sessionChanges.delete(sessionId)
+            }
+        }
+    }
+
+    /**
+     * Find an existing pending change for the same target path in a session.
+     */
+    private findPendingChangeForPath(filePath: string, sessionId: string): FileChange | undefined {
+        const ids = this.sessionChanges.get(sessionId) || []
+        for (const id of ids) {
+            const change = this.pendingChanges.get(id)
+            if (change && change.originalPath === filePath) return change
+        }
+        return undefined
+    }
+
+    /**
      * Check if Safe Mode is enabled
      * @private
      */
@@ -236,6 +263,20 @@ export class FileSystemService {
         content: string,
         sessionId: string = 'default'
     ): Promise<FileChange> {
+        // Coalesce repeated writes to the same file into one pending entry.
+        // This prevents the review panel from growing with duplicate looped writes.
+        const existing = this.findPendingChangeForPath(filePath, sessionId)
+        if (existing) {
+            await fs.mkdir(path.dirname(existing.shadowPath), { recursive: true })
+            await fs.writeFile(existing.shadowPath, content, 'utf8')
+            existing.type = await this.fileExists(filePath) ? 'modify' : 'create'
+            existing.content = content.length < 10000 ? content : undefined
+            existing.timestamp = Date.now()
+            this.pendingChanges.set(existing.id, existing)
+            console.log(`[FileSystemService] Updated staged ${existing.type} for ${filePath} (ID: ${existing.id})`)
+            return existing
+        }
+
         const changeId = randomUUID()
         const shadowPath = path.join(this.shadowDir, sessionId, changeId)
         const type = await this.fileExists(filePath) ? 'modify' : 'create'
@@ -283,6 +324,7 @@ export class FileSystemService {
             // Cleanup
             await fs.rm(change.shadowPath)
             this.pendingChanges.delete(changeId)
+            this.removeChangeFromSessions(changeId)
 
             console.log(`[FileSystemService] ✓ Committed ${change.type} to ${change.originalPath}`)
         } catch (error) {
@@ -302,6 +344,7 @@ export class FileSystemService {
         try {
             await fs.rm(change.shadowPath)
             this.pendingChanges.delete(changeId)
+            this.removeChangeFromSessions(changeId)
             console.log(`[FileSystemService] ✗ Discarded ${change.type} for ${change.originalPath}`)
         } catch (error) {
             console.error(`[FileSystemService] Failed to discard ${changeId}:`, error)
@@ -315,7 +358,23 @@ export class FileSystemService {
      */
     getPendingChanges(sessionId: string = 'default'): FileChange[] {
         const ids = this.sessionChanges.get(sessionId) || []
-        return ids.map(id => this.pendingChanges.get(id)!).filter(Boolean)
+        const resolved: FileChange[] = []
+        const aliveIds: string[] = []
+
+        for (const id of ids) {
+            const change = this.pendingChanges.get(id)
+            if (!change) continue
+            resolved.push(change)
+            aliveIds.push(id)
+        }
+
+        // Heal stale session index entries opportunistically.
+        if (aliveIds.length !== ids.length) {
+            if (aliveIds.length > 0) this.sessionChanges.set(sessionId, aliveIds)
+            else this.sessionChanges.delete(sessionId)
+        }
+
+        return resolved
     }
 
     // ========================================================================

--- a/src/main/services/FileSystemService.ts
+++ b/src/main/services/FileSystemService.ts
@@ -234,17 +234,64 @@ export class FileSystemService {
         }
     }
 
+    private normalizePathForCompare(value: string): string {
+        return path.resolve(value).replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
+    }
+
+    private isPathWithin(rootPath: string, targetPath: string): boolean {
+        const normalizedRoot = this.normalizePathForCompare(rootPath)
+        const normalizedTarget = this.normalizePathForCompare(targetPath)
+        return normalizedTarget === normalizedRoot || normalizedTarget.startsWith(`${normalizedRoot}/`)
+    }
+
+    private resolveWorkspaceForUserOps(workspacePath: unknown): string {
+        if (typeof workspacePath !== 'string' || workspacePath.trim() === '') {
+            throw new Error('WORKSPACE REQUIRED: Select a workspace folder before filesystem operations.')
+        }
+
+        const resolvedWorkspace = path.resolve(workspacePath.trim())
+        const userHome = app.getPath('home')
+        if (!this.isPathWithin(userHome, resolvedWorkspace)) {
+            throw new Error(`WORKSPACE REQUIRED: Workspace must be inside your user home folder (${userHome}).`)
+        }
+
+        return resolvedWorkspace
+    }
+
+    private resolveWorkspaceScopedTargetPath(
+        targetPath: unknown,
+        workspacePath: unknown,
+        toolName: string
+    ): string {
+        if (typeof targetPath !== 'string' || targetPath.trim() === '') {
+            throw new Error(`Missing required path for ${toolName}.`)
+        }
+
+        const resolvedWorkspace = this.resolveWorkspaceForUserOps(workspacePath)
+        const rawTargetPath = targetPath.trim()
+        const resolvedTarget = path.isAbsolute(rawTargetPath)
+            ? path.resolve(rawTargetPath)
+            : path.resolve(resolvedWorkspace, rawTargetPath)
+
+        if (!this.isPathWithin(resolvedWorkspace, resolvedTarget)) {
+            throw new Error(
+                `SECURITY VIOLATION: Access denied. Path '${resolvedTarget}' is outside the active workspace '${resolvedWorkspace}'.`
+            )
+        }
+
+        return resolvedTarget
+    }
+
     /**
      * Internal tracking files are written by the app itself and should not
      * require staged user approval even when Safe Mode is enabled.
      */
     private isInternalTrackingFile(filePath: string): boolean {
-        const normalized = path.normalize(filePath)
-        const parentDir = path.basename(path.dirname(normalized)).toLowerCase()
-        const fileName = path.basename(normalized).toLowerCase()
+        const fileName = path.basename(filePath).toLowerCase()
+        if (fileName !== 'tasks.json' && fileName !== 'execution-plan.json') return false
 
-        if (parentDir !== '.ai-worker') return false
-        return fileName === 'tasks.json' || fileName === 'execution-plan.json'
+        const internalRoot = path.resolve(path.join(app.getPath('home'), '.ai-worker', 'system-workspace'))
+        return this.isPathWithin(internalRoot, path.resolve(filePath))
     }
 
     // ========================================================================
@@ -397,11 +444,21 @@ export class FileSystemService {
             switch (name) {
                 case 'fs_write_file': {
                     const { safeMode: isSafeMode, autoApprove } = await this.getSafeModeSettings()
-                    const isInternalTrackingWrite = this.isInternalTrackingFile(args.path)
+                    const resolvedPath = this.resolveWorkspaceScopedTargetPath(args?.path, args?.workspacePath, name)
+                    const isInternalTrackingWrite = this.isInternalTrackingFile(resolvedPath)
+                    const sessionId =
+                        typeof args?._sessionId === 'string' && args._sessionId.trim() !== ''
+                            ? args._sessionId.trim()
+                            : 'default'
+                    const hasSessionAutoApproveOverride = typeof args?._sessionAutoApprove === 'boolean'
+                    const sessionAutoApprove = args?._sessionAutoApprove === true
+                    const effectiveAutoApprove = hasSessionAutoApproveOverride
+                        ? sessionAutoApprove
+                        : autoApprove
 
-                    if (isSafeMode && !autoApprove && !isInternalTrackingWrite) {
+                    if (isSafeMode && !effectiveAutoApprove && !isInternalTrackingWrite) {
                         // Safe Mode: Stage for user review
-                        const change = await this.stageWrite(args.path, args.content)
+                        const change = await this.stageWrite(resolvedPath, args.content, sessionId)
                         return {
                             result: {
                                 status: 'staged',
@@ -414,34 +471,40 @@ export class FileSystemService {
                         // - Safe Mode disabled OR
                         // - Auto-approve enabled OR
                         // - Internal tracking file
-                        await fs.mkdir(path.dirname(args.path), { recursive: true })
-                        await fs.writeFile(args.path, args.content, 'utf8')
+                        await fs.mkdir(path.dirname(resolvedPath), { recursive: true })
+                        await fs.writeFile(resolvedPath, args.content, 'utf8')
                         const status = isInternalTrackingWrite
                             ? 'written_internal'
-                            : autoApprove
+                            : sessionAutoApprove
+                                ? 'written_session_auto_approved'
+                                : autoApprove
                                 ? 'written_auto_approved'
                                 : 'written'
                         return {
                             result: {
                                 status,
-                                path: args.path,
+                                path: resolvedPath,
                                 message: isInternalTrackingWrite
-                                    ? `Internal tracking file updated: ${args.path}`
+                                    ? `Internal tracking file updated: ${resolvedPath}`
+                                    : sessionAutoApprove
+                                        ? `File written with session auto-approval: ${resolvedPath}`
                                     : autoApprove
-                                        ? `File written with auto-approval: ${args.path}`
-                                    : `File written to ${args.path}`
+                                        ? `File written with auto-approval: ${resolvedPath}`
+                                    : `File written to ${resolvedPath}`
                             }
                         }
                     }
                 }
 
                 case 'fs_read_file': {
-                    const content = await fs.readFile(args.path, 'utf8')
+                    const resolvedPath = this.resolveWorkspaceScopedTargetPath(args?.path, args?.workspacePath, name)
+                    const content = await fs.readFile(resolvedPath, 'utf8')
                     return { result: content }
                 }
 
                 case 'fs_list_directory': {
-                    const files = await fs.readdir(args.path)
+                    const resolvedPath = this.resolveWorkspaceScopedTargetPath(args?.path, args?.workspacePath, name)
+                    const files = await fs.readdir(resolvedPath)
                     return { result: files }
                 }
 

--- a/src/main/services/FileSystemService.ts
+++ b/src/main/services/FileSystemService.ts
@@ -250,11 +250,6 @@ export class FileSystemService {
         }
 
         const resolvedWorkspace = path.resolve(workspacePath.trim())
-        const userHome = app.getPath('home')
-        if (!this.isPathWithin(userHome, resolvedWorkspace)) {
-            throw new Error(`WORKSPACE REQUIRED: Workspace must be inside your user home folder (${userHome}).`)
-        }
-
         return resolvedWorkspace
     }
 

--- a/src/main/services/playwright/tools/TabTools.ts
+++ b/src/main/services/playwright/tools/TabTools.ts
@@ -88,14 +88,26 @@ export class CloseTabTool extends PlaywrightTool {
         };
     }
 
-    async execute(page: Page, _args: any, context?: PlaywrightContext): Promise<ToolResult> {
+    async execute(page: Page, args: any, context?: PlaywrightContext): Promise<ToolResult> {
         if (!context?.context) throw new Error('No browser context');
-        // If args.tabId or args.index is provided, use that, otherwise use current page
-        // (PlaywrightService.getPage handles this logic usually, but here we can be explicit)
-        const pageToClose = page; // Currently we just close the page passed in
+        // If a tab id/index was requested, resolve it explicitly from pagesMap.
+        // This prevents accidental closure of the current page when a stale tabId
+        // is passed and BrowserManager falls back to the active page.
+        let pageToClose = page;
+        const requestedTabId = typeof args?.tabId === 'number'
+            ? args.tabId
+            : (typeof args?.index === 'number' ? args.index : undefined);
+        if (requestedTabId !== undefined) {
+            const requestedPage = context.pagesMap.get(requestedTabId);
+            if (!requestedPage || requestedPage.isClosed()) {
+                return { result: null, error: `Tab ID ${requestedTabId} not found` };
+            }
+            pageToClose = requestedPage;
+        }
+        const forceCloseLastTab = args?.force === true;
 
         const openPages = context.context.pages().filter(p => !p.isClosed());
-        if (openPages.length <= 1) {
+        if (openPages.length <= 1 && !forceCloseLastTab) {
             return { result: 'Skipped close_tab: last tab remains open' };
         }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -46,6 +46,7 @@ const electronAPI = {
     app: {
         getVersion: () => ipcRenderer.invoke('app:get-version'),
         getName: () => ipcRenderer.invoke('app:get-name'),
+        getHomePath: () => ipcRenderer.invoke('app:get-home-path'),
         selectFolder: () => ipcRenderer.invoke('app:select-folder'),
         getMissingDependencies: () => ipcRenderer.invoke('app:get-missing-dependencies'),
         getAllDependencies: () => ipcRenderer.invoke('app:get-all-dependencies'),
@@ -99,7 +100,7 @@ const electronAPI = {
     },
     // Filesystem Safe Mode operations
     fs: {
-        getPendingChanges: () => ipcRenderer.invoke('fs:get-pending-changes'),
+        getPendingChanges: (sessionId?: string) => ipcRenderer.invoke('fs:get-pending-changes', sessionId),
         approveChange: (changeId: string) => ipcRenderer.invoke('fs:approve-change', changeId),
         rejectChange: (changeId: string) => ipcRenderer.invoke('fs:reject-change', changeId),
         writeInternalFile: (workspacePath: string | undefined, filename: string, content: string) =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -39,6 +39,12 @@ import { useThemeSync } from "./hooks/useThemeSync";
 
 function App() {
   const [currentView, setCurrentView] = useState<View>("chat");
+  
+  // Expose store for E2E tests
+  if (import.meta.env.MODE === 'test') {
+    (window as any).useChatStore = useChatStore;
+  }
+
   const [dependenciesResolved, setDependenciesResolved] = useState(() => {
     // Only skip the long background shell check during automated test runs.
     // Using process.env.NODE_ENV ensures this bypass is compile-time and

--- a/src/renderer/src/components/FileChangeReview.tsx
+++ b/src/renderer/src/components/FileChangeReview.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { FileText, Check, X, AlertTriangle, RefreshCw, Clock3 } from 'lucide-react'
+import { useChatStore } from '../stores/chatStore'
 import { useSettingsStore } from '../stores/settingsStore'
 
 interface FileChange {
@@ -13,30 +14,61 @@ interface FileChange {
 
 export const FileChangeReview: React.FC = () => {
     const [changes, setChanges] = useState<FileChange[]>([])
+    const [autoApproveErrorIds, setAutoApproveErrorIds] = useState<Set<string>>(new Set())
     const [isLoading, setIsLoading] = useState(false)
     const INTERNAL_TRACKING_FILE_PATTERN = /[\\/]\.ai-worker[\\/](tasks|execution-plan)\.json$/i
+    const { activeSessionId, sessions } = useChatStore()
     const fileSystemAutoApprove = useSettingsStore((s) => s.fileSystemAutoApprove)
+    const activeSession = sessions.find((s) => s.id === activeSessionId)
+    const sessionAutoApprove = activeSession?.fileWriteAutoApprove ?? fileSystemAutoApprove
 
     const fetchChanges = async () => {
         setIsLoading(true)
         try {
-            const pending = await window?.electron?.fs.getPendingChanges()
+            const pending = await window?.electron?.fs.getPendingChanges(activeSessionId || 'default')
             if (pending) {
                 // Internal task tracking writes should not surface in the review panel.
                 const filtered = pending.filter(
                     (change: FileChange) => !INTERNAL_TRACKING_FILE_PATTERN.test(change.originalPath)
                 )
+                const pendingIds = new Set(filtered.map((change: FileChange) => change.id))
+                setAutoApproveErrorIds((prev) => {
+                    const next = new Set(Array.from(prev).filter((id) => pendingIds.has(id)))
+                    if (next.size === prev.size && Array.from(next).every((id) => prev.has(id))) return prev
+                    return next
+                })
 
                 // If Auto-Approve is enabled, sweep backlog entries so this panel
                 // doesn't keep reappearing with stale pending writes.
-                if (fileSystemAutoApprove && filtered.length > 0) {
+                if (sessionAutoApprove && filtered.length > 0) {
+                    // Do not repeatedly retry entries that already failed auto-approval.
+                    // Keep them visible for manual approval/rejection instead.
+                    const autoSweepCandidates = filtered.filter(
+                        (change: FileChange) => !autoApproveErrorIds.has(change.id)
+                    )
+                    if (autoSweepCandidates.length === 0) {
+                        setChanges(filtered)
+                        return
+                    }
                     const settle = await Promise.all(
-                        filtered.map((change) =>
-                            window?.electron?.fs.approveChange(change.id).catch(() => ({ success: false }))
+                        autoSweepCandidates.map((change) =>
+                            window?.electron?.fs.approveChange(change.id)
+                                .then(() => ({ success: true }))
+                                .catch(() => ({ success: false }))
                         )
                     )
-                    const failed = filtered.filter((_change, idx) => !settle[idx]?.success)
-                    setChanges(failed)
+                    const failedIds = autoSweepCandidates
+                        .filter((_change, idx) => !settle[idx]?.success)
+                        .map((change) => change.id)
+                    if (failedIds.length > 0) {
+                        setAutoApproveErrorIds((prev) => {
+                            const next = new Set(prev)
+                            for (const id of failedIds) next.add(id)
+                            if (next.size === prev.size && failedIds.every((id) => prev.has(id))) return prev
+                            return next
+                        })
+                    }
+                    setChanges(filtered)
                     return
                 }
 
@@ -54,11 +86,16 @@ export const FileChangeReview: React.FC = () => {
         // Poll for changes every 2 seconds
         const interval = setInterval(fetchChanges, 2000)
         return () => clearInterval(interval)
-    }, [fileSystemAutoApprove])
+    }, [activeSessionId, sessionAutoApprove, autoApproveErrorIds])
 
     const handleApprove = async (id: string) => {
         try {
             await window?.electron?.fs.approveChange(id)
+            setAutoApproveErrorIds((prev) => {
+                const next = new Set(prev)
+                next.delete(id)
+                return next
+            })
             setChanges(prev => prev.filter(c => c.id !== id))
         } catch (error) {
             console.error('Failed to approve change:', error)
@@ -68,6 +105,11 @@ export const FileChangeReview: React.FC = () => {
     const handleReject = async (id: string) => {
         try {
             await window?.electron?.fs.rejectChange(id)
+            setAutoApproveErrorIds((prev) => {
+                const next = new Set(prev)
+                next.delete(id)
+                return next
+            })
             setChanges(prev => prev.filter(c => c.id !== id))
         } catch (error) {
             console.error('Failed to reject change:', error)

--- a/src/renderer/src/components/FileChangeReview.tsx
+++ b/src/renderer/src/components/FileChangeReview.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { FileText, Check, X, AlertTriangle, RefreshCw, Clock3 } from 'lucide-react'
+import { useSettingsStore } from '../stores/settingsStore'
 
 interface FileChange {
     id: string
@@ -14,6 +15,7 @@ export const FileChangeReview: React.FC = () => {
     const [changes, setChanges] = useState<FileChange[]>([])
     const [isLoading, setIsLoading] = useState(false)
     const INTERNAL_TRACKING_FILE_PATTERN = /[\\/]\.ai-worker[\\/](tasks|execution-plan)\.json$/i
+    const fileSystemAutoApprove = useSettingsStore((s) => s.fileSystemAutoApprove)
 
     const fetchChanges = async () => {
         setIsLoading(true)
@@ -24,6 +26,20 @@ export const FileChangeReview: React.FC = () => {
                 const filtered = pending.filter(
                     (change: FileChange) => !INTERNAL_TRACKING_FILE_PATTERN.test(change.originalPath)
                 )
+
+                // If Auto-Approve is enabled, sweep backlog entries so this panel
+                // doesn't keep reappearing with stale pending writes.
+                if (fileSystemAutoApprove && filtered.length > 0) {
+                    const settle = await Promise.all(
+                        filtered.map((change) =>
+                            window?.electron?.fs.approveChange(change.id).catch(() => ({ success: false }))
+                        )
+                    )
+                    const failed = filtered.filter((_change, idx) => !settle[idx]?.success)
+                    setChanges(failed)
+                    return
+                }
+
                 setChanges(filtered)
             }
         } catch (error) {
@@ -38,7 +54,7 @@ export const FileChangeReview: React.FC = () => {
         // Poll for changes every 2 seconds
         const interval = setInterval(fetchChanges, 2000)
         return () => clearInterval(interval)
-    }, [])
+    }, [fileSystemAutoApprove])
 
     const handleApprove = async (id: string) => {
         try {

--- a/src/renderer/src/components/FileChangeReview.tsx
+++ b/src/renderer/src/components/FileChangeReview.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react'
-import { FileText, Check, X, AlertTriangle, RefreshCw } from 'lucide-react'
+import React, { useEffect, useMemo, useState } from 'react'
+import { FileText, Check, X, AlertTriangle, RefreshCw, Clock3 } from 'lucide-react'
 
 interface FileChange {
     id: string
@@ -13,12 +13,19 @@ interface FileChange {
 export const FileChangeReview: React.FC = () => {
     const [changes, setChanges] = useState<FileChange[]>([])
     const [isLoading, setIsLoading] = useState(false)
+    const INTERNAL_TRACKING_FILE_PATTERN = /[\\/]\.ai-worker[\\/](tasks|execution-plan)\.json$/i
 
     const fetchChanges = async () => {
         setIsLoading(true)
         try {
             const pending = await window?.electron?.fs.getPendingChanges()
-            if(pending)setChanges(pending)
+            if (pending) {
+                // Internal task tracking writes should not surface in the review panel.
+                const filtered = pending.filter(
+                    (change: FileChange) => !INTERNAL_TRACKING_FILE_PATTERN.test(change.originalPath)
+                )
+                setChanges(filtered)
+            }
         } catch (error) {
             console.error('Failed to fetch changes:', error)
         } finally {
@@ -51,41 +58,71 @@ export const FileChangeReview: React.FC = () => {
         }
     }
 
+    const sortedChanges = useMemo(
+        () => [...changes].sort((a, b) => b.timestamp - a.timestamp),
+        [changes]
+    )
+
     if (changes.length === 0) return null
 
     return (
-        <div className="fixed bottom-4 right-4 z-50 w-96 flex flex-col gap-2">
-            <div className="bg-card border border-border shadow-lg rounded-lg overflow-hidden flex flex-col max-h-[80vh]">
-                <div className="bg-primary/10 p-3 border-b border-border flex items-center justify-between">
+        <div className="fixed bottom-4 right-4 z-50 w-[30rem] max-w-[calc(100vw-1.5rem)]">
+            <div className="overflow-hidden rounded-2xl border border-[var(--color-border)] bg-[var(--color-card-elevated)] shadow-2xl">
+                <div className="border-b border-[var(--color-border)] bg-gradient-to-r from-amber-400/15 to-transparent px-4 py-3">
                     <div className="flex items-center gap-2">
-                        <AlertTriangle className="w-4 h-4 text-warning" />
-                        <h3 className="font-semibold text-sm">Review File Changes ({changes.length})</h3>
+                        <AlertTriangle className="h-4 w-4 text-amber-300" />
+                        <div className="flex-1">
+                            <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                                Review Pending File Writes
+                            </h3>
+                            <p className="text-[11px] text-[var(--color-text-muted)]">
+                                {changes.length} change{changes.length === 1 ? '' : 's'} waiting for approval
+                            </p>
+                        </div>
+                        <button
+                            onClick={fetchChanges}
+                            className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-muted)] transition hover:text-[var(--color-text-primary)]"
+                            disabled={isLoading}
+                            title="Refresh"
+                        >
+                            <RefreshCw className={`h-3.5 w-3.5 ${isLoading ? 'animate-spin' : ''}`} />
+                        </button>
                     </div>
-                    <button onClick={fetchChanges} className="p-1 hover:bg-background rounded-full" disabled={isLoading}>
-                        <RefreshCw className={`w-3 h-3 ${isLoading ? 'animate-spin' : ''}`} />
-                    </button>
                 </div>
 
-                <div className="overflow-y-auto p-2 space-y-2">
-                    {changes.map(change => (
-                        <div key={change.id} className="bg-background border border-border rounded p-3 text-xs shadow-sm">
-                            <div className="flex items-start gap-2">
-                                <FileText className="w-4 h-4 text-muted-foreground mt-0.5" />
+                <div className="max-h-[68vh] space-y-3 overflow-y-auto p-3">
+                    {sortedChanges.map(change => (
+                        <div
+                            key={change.id}
+                            className="rounded-xl border border-[var(--color-border)] bg-[var(--color-card)] p-3"
+                        >
+                            <div className="flex items-start gap-3">
+                                <div className="mt-0.5 rounded-lg bg-[var(--color-surface)] p-2">
+                                    <FileText className="h-4 w-4 text-[var(--color-text-muted)]" />
+                                </div>
                                 <div className="flex-1 min-w-0">
-                                    <div className="font-medium truncate" title={change.originalPath}>
-                                        {change.originalPath.split('/').pop()}
+                                    <div
+                                        className="truncate text-sm font-medium text-[var(--color-text-primary)]"
+                                        title={change.originalPath}
+                                    >
+                                        {change.originalPath.split(/[\\/]/).pop() || change.originalPath}
                                     </div>
-                                    <div className="text-muted-foreground truncate text-[10px]">
+                                    <div className="mt-0.5 truncate font-mono text-[10px] text-[var(--color-text-dim)]">
                                         {change.originalPath}
                                     </div>
-                                    <div className="mt-1 flex items-center gap-2">
-                                        <span className={`px-1.5 py-0.5 rounded text-[10px] uppercase font-bold
-                                            ${change.type === 'create' ? 'bg-green-500/20 text-green-500' : 
-                                              change.type === 'delete' ? 'bg-red-500/20 text-red-500' : 
-                                              'bg-yellow-500/20 text-yellow-500'}`}>
+                                    <div className="mt-2 flex items-center gap-2">
+                                        <span
+                                            className={`rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${change.type === 'create'
+                                                ? 'bg-emerald-500/15 text-emerald-300'
+                                                : change.type === 'delete'
+                                                    ? 'bg-red-500/15 text-red-300'
+                                                    : 'bg-amber-500/15 text-amber-300'
+                                                }`}
+                                        >
                                             {change.type}
                                         </span>
-                                        <span className="text-muted-foreground text-[10px]">
+                                        <span className="inline-flex items-center gap-1 text-[10px] text-[var(--color-text-dim)]">
+                                            <Clock3 className="h-3 w-3" />
                                             {new Date(change.timestamp).toLocaleTimeString()}
                                         </span>
                                     </div>
@@ -93,24 +130,32 @@ export const FileChangeReview: React.FC = () => {
                             </div>
 
                             {change.content && (
-                                <div className="mt-2 bg-muted/50 p-2 rounded overflow-hidden max-h-24 font-mono text-[10px] whitespace-pre-wrap break-all">
-                                    {change.content.substring(0, 200)}
-                                    {change.content.length > 200 && '...'}
+                                <div className="mt-3 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] p-2 font-mono text-[11px] leading-4 text-[var(--color-text-secondary)]">
+                                    <pre className="max-h-28 overflow-auto whitespace-pre-wrap break-all">
+                                        {change.content.substring(0, 320)}
+                                        {change.content.length > 320 && '...'}
+                                    </pre>
                                 </div>
                             )}
 
                             <div className="mt-3 flex gap-2">
-                                <button 
+                                <button
                                     onClick={() => handleApprove(change.id)}
-                                    className="flex-1 bg-green-600 hover:bg-green-700 text-white py-1.5 rounded flex items-center justify-center gap-1 transition-colors"
+                                    className="flex-1 rounded-md border border-emerald-500/35 bg-emerald-500/20 px-3 py-2 text-xs font-medium text-emerald-100 transition hover:bg-emerald-500/30"
                                 >
-                                    <Check className="w-3 h-3" /> Approve
+                                    <span className="inline-flex items-center gap-1">
+                                        <Check className="h-3.5 w-3.5" />
+                                        Approve
+                                    </span>
                                 </button>
-                                <button 
+                                <button
                                     onClick={() => handleReject(change.id)}
-                                    className="flex-1 bg-red-600 hover:bg-red-700 text-white py-1.5 rounded flex items-center justify-center gap-1 transition-colors"
+                                    className="flex-1 rounded-md border border-red-500/35 bg-red-500/20 px-3 py-2 text-xs font-medium text-red-100 transition hover:bg-red-500/30"
                                 >
-                                    <X className="w-3 h-3" /> Reject
+                                    <span className="inline-flex items-center gap-1">
+                                        <X className="h-3.5 w-3.5" />
+                                        Reject
+                                    </span>
                                 </button>
                             </div>
                         </div>

--- a/src/renderer/src/components/Header.tsx
+++ b/src/renderer/src/components/Header.tsx
@@ -57,9 +57,9 @@ export function Header({ status }: HeaderProps) {
                 )}
             </div>
 
-            <div className="text-[10px] uppercase tracking-widest text-[var(--color-text-dim)] hidden sm:flex items-center gap-2">
+            <div className="text-[10px] uppercase tracking-widest text-[var(--color-text-dim)] flex items-center gap-2">
                 <StatusDot variant="success" size="sm" animated />
-                local-session: active
+                <span className="hidden sm:inline">local-session: active</span>
 
                 {/* WhatsApp status indicator */}
                 {isWhatsAppConnected && (

--- a/src/renderer/src/components/SettingsPanel.tsx
+++ b/src/renderer/src/components/SettingsPanel.tsx
@@ -273,6 +273,42 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
                                 </div>
                             </div>
 
+                            {/* Filesystem Safe Mode */}
+                            <div className="bg-[var(--color-card-elevated)] border border-[var(--color-border)] rounded-xl p-4 mb-4">
+                                <div className="flex items-center justify-between gap-4">
+                                    <div>
+                                        <label className="block text-sm text-[var(--color-text-primary)] mb-1">Filesystem Safe Mode</label>
+                                        <p className="text-xs text-[var(--color-text-muted)]">
+                                            Stage AI file edits for approval before writing to disk.
+                                        </p>
+                                    </div>
+                                    <input
+                                        type="checkbox"
+                                        className="toggle toggle-success"
+                                        checked={settings.fileSystemSafeMode}
+                                        onChange={() => settings.setFileSystemSafeMode(!settings.fileSystemSafeMode)}
+                                    />
+                                </div>
+                            </div>
+
+                            {/* Filesystem Auto-Approve */}
+                            <div className="bg-[var(--color-card-elevated)] border border-[var(--color-border)] rounded-xl p-4 mb-4">
+                                <div className="flex items-center justify-between gap-4">
+                                    <div>
+                                        <label className="block text-sm text-[var(--color-text-primary)] mb-1">Auto-Approve AI File Writes</label>
+                                        <p className="text-xs text-[var(--color-text-muted)]">
+                                            Automatically apply staged writes. Disable to review each change manually.
+                                        </p>
+                                    </div>
+                                    <input
+                                        type="checkbox"
+                                        className="toggle toggle-success"
+                                        checked={settings.fileSystemAutoApprove}
+                                        onChange={() => settings.setFileSystemAutoApprove(!settings.fileSystemAutoApprove)}
+                                    />
+                                </div>
+                            </div>
+
                             {/* Info Box */}
                             <div className="bg-[var(--color-brand-teal)]/10 border border-[var(--color-brand-teal)]/30 rounded-xl p-4">
                                 <div className="flex items-start gap-3">

--- a/src/renderer/src/components/input/ChatInput.tsx
+++ b/src/renderer/src/components/input/ChatInput.tsx
@@ -17,6 +17,7 @@ import { useSpeechRecognition } from '../../hooks/useSpeechRecognition'
 import { useFileDragDrop } from '../../hooks/useFileDragDrop'
 import { useLogStore } from '../../stores/logStore'
 import { useChatStore } from '../../stores/chatStore'
+import { useSettingsStore } from '../../stores/settingsStore'
 import { useWhatsAppStore } from '../../stores/whatsappStore'
 import electron from '../../lib/electron'
 
@@ -33,22 +34,50 @@ interface ChatInputProps {
   onAbort?: () => void
 }
 
+function normalizePathForCompare(value: string): string {
+  return value.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
+}
+
+function isPathInside(rootPath: string, targetPath: string): boolean {
+  const normalizedRoot = normalizePathForCompare(rootPath)
+  const normalizedTarget = normalizePathForCompare(targetPath)
+  return normalizedTarget === normalizedRoot || normalizedTarget.startsWith(`${normalizedRoot}/`)
+}
+
 export function ChatInput({ onSubmit, disabled = false, onAbort }: ChatInputProps) {
   const [textInput, setTextInput] = useState('')
   const [isHeadless, setIsHeadless] = useState(false)
   const [workspacePath, setWorkspacePath] = useState<string | null>(null)
+  const [sessionFileWriteAutoApprove, setSessionFileWriteAutoApproveState] = useState<boolean | undefined>(undefined)
+  const [userHomePath, setUserHomePath] = useState<string | null>(null)
   const [attachments, setAttachments] = useState<File[]>([])
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileSystemAutoApprove = useSettingsStore((s) => s.fileSystemAutoApprove)
   const { addLog } = useLogStore()
-  const { activeSessionId, getActiveSession } = useChatStore()
+  const { activeSessionId, getActiveSession, setSessionFileWriteAutoApprove } = useChatStore()
   const { whatsappEnabled, connectionState } = useWhatsAppStore()
 
   // Load workspace from active session and reset per-session state
   useEffect(() => {
     const session = getActiveSession()
     setWorkspacePath(session?.workspacePath || null)
+    setSessionFileWriteAutoApproveState(session?.fileWriteAutoApprove)
     setIsHeadless(false)
   }, [activeSessionId, getActiveSession])
+
+  const effectiveFileWriteAutoApprove = sessionFileWriteAutoApprove ?? fileSystemAutoApprove
+
+  useEffect(() => {
+    let mounted = true
+    electron.getHomePath()
+      .then((homePath) => {
+        if (mounted && homePath) setUserHomePath(homePath)
+      })
+      .catch((error) => {
+        console.warn('[ChatInput] Failed to resolve user home path:', error)
+      })
+    return () => { mounted = false }
+  }, [])
 
   // Speech recognition hook
   const {
@@ -124,6 +153,10 @@ export function ChatInput({ onSubmit, disabled = false, onAbort }: ChatInputProp
     try {
       const selectedPath = await electron.selectFolder()
       if (selectedPath) {
+        if (userHomePath && !isPathInside(userHomePath, selectedPath)) {
+          console.warn('[ChatInput] Rejected workspace outside user home folder:', selectedPath)
+          return
+        }
         setWorkspacePath(selectedPath)
         const {
           createSession,
@@ -147,7 +180,7 @@ export function ChatInput({ onSubmit, disabled = false, onAbort }: ChatInputProp
     } catch (error) {
       console.error('Failed to select folder:', error)
     }
-  }, [addLog])
+  }, [addLog, userHomePath])
 
   // Derive workspace from file path if none is set
   const maybeSetWorkspaceFromFiles = useCallback((files: File[]) => {
@@ -156,8 +189,13 @@ export function ChatInput({ onSubmit, disabled = false, onAbort }: ChatInputProp
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const firstPath = (window as any).electron?.utils?.getPathForFile(firstFile) || (firstFile as any).path as string | undefined
     if (!firstPath) return
-    const parentDir = firstPath.includes('/') ? firstPath.substring(0, firstPath.lastIndexOf('/')) : null
+    const lastSlash = Math.max(firstPath.lastIndexOf('/'), firstPath.lastIndexOf('\\'))
+    const parentDir = lastSlash > 0 ? firstPath.substring(0, lastSlash) : null
     if (!parentDir) return
+    if (userHomePath && !isPathInside(userHomePath, parentDir)) {
+      console.warn('[ChatInput] Skipping auto-derived workspace outside user home folder:', parentDir)
+      return
+    }
     setWorkspacePath(parentDir)
     const { createSession, activeSessionId: currentSessionId, updateSessionWorkspace } = useChatStore.getState()
     if (!currentSessionId) {
@@ -165,7 +203,7 @@ export function ChatInput({ onSubmit, disabled = false, onAbort }: ChatInputProp
     } else {
       updateSessionWorkspace(currentSessionId, parentDir)
     }
-  }, [workspacePath])
+  }, [workspacePath, userHomePath])
 
   // Handle files selected via toolbar dropdown
   const handleSelectFiles = useCallback((files: File[]) => {
@@ -325,7 +363,14 @@ export function ChatInput({ onSubmit, disabled = false, onAbort }: ChatInputProp
             <InputToolbar
               workspacePath={workspacePath}
               isHeadless={isHeadless}
+              fileWriteAutoApprove={effectiveFileWriteAutoApprove}
               onToggleHeadless={() => setIsHeadless(!isHeadless)}
+              onToggleFileWriteAutoApprove={() => {
+                if (!activeSessionId) return
+                const nextValue = !effectiveFileWriteAutoApprove
+                setSessionFileWriteAutoApproveState(nextValue)
+                setSessionFileWriteAutoApprove(activeSessionId, nextValue)
+              }}
               onSelectFolder={handleSelectFolder}
               onSelectFiles={handleSelectFiles}
               hasAttachments={attachments.length > 0}

--- a/src/renderer/src/components/input/InputToolbar.tsx
+++ b/src/renderer/src/components/input/InputToolbar.tsx
@@ -1,11 +1,12 @@
-import React, { useState, useRef, useEffect } from 'react'
-import { Eye, EyeOff, Paperclip, FolderOpen, File as FileIcon } from 'lucide-react'
-import { Button } from '../primitives/Button'
+import React, { useRef } from 'react'
+import { Eye, EyeOff, Paperclip, FolderOpen, ShieldCheck, ShieldAlert } from 'lucide-react'
 
 interface InputToolbarProps {
   workspacePath: string | null
   isHeadless: boolean
+  fileWriteAutoApprove: boolean
   onToggleHeadless: () => void
+  onToggleFileWriteAutoApprove: () => void
   onSelectFolder: () => void
   onSelectFiles: (files: File[]) => void
   hasAttachments: boolean
@@ -15,14 +16,14 @@ interface InputToolbarProps {
 export function InputToolbar({
   workspacePath,
   isHeadless,
+  fileWriteAutoApprove,
   onToggleHeadless,
+  onToggleFileWriteAutoApprove,
   onSelectFolder,
   onSelectFiles,
   hasAttachments,
   disabled = false,
 }: InputToolbarProps) {
-  const [showContextMenu, setShowContextMenu] = useState(false)
-  const contextMenuRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -31,18 +32,6 @@ export function InputToolbar({
       e.target.value = ''
     }
   }
-
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (contextMenuRef.current && !contextMenuRef.current.contains(e.target as Node)) {
-        setShowContextMenu(false)
-      }
-    }
-    if (showContextMenu) {
-      document.addEventListener('mousedown', handleClickOutside)
-    }
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [showContextMenu])
 
   return (
     <>
@@ -54,64 +43,55 @@ export function InputToolbar({
         style={{ display: 'none' }}
       />
 
-      {/* Unified Workspace / File Selector */}
-      <div className="relative" ref={contextMenuRef}>
-        <button
-          onClick={() => setShowContextMenu(!showContextMenu)}
-          disabled={disabled}
-          className={`p-2 mb-[1px] rounded-[var(--radius-lg)] transition-all h-[44px] w-[36px] flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] ${workspacePath
-              ? 'bg-[var(--color-brand-teal)]/20 text-[var(--color-brand-teal)] hover:bg-[var(--color-brand-teal)]/30'
-              : hasAttachments
-                ? 'bg-[var(--color-success)]/20 text-[var(--color-success)] hover:bg-[var(--color-success)]/30'
-                : 'bg-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-surface)]'
-            } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
-          title={workspacePath ? `Workspace: ${workspacePath}` : 'Select workspace or files'}
-        >
-          <Paperclip size={18} />
-        </button>
+      <button
+        id="workspace-select-button"
+        data-testid="workspace-select-button"
+        type="button"
+        onClick={onSelectFolder}
+        disabled={disabled}
+        className={`inline-flex h-[36px] items-center gap-1.5 rounded-[var(--radius-lg)] border px-2 text-[10px] font-semibold tracking-wide transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] ${workspacePath
+            ? 'border-[var(--color-brand-teal)]/40 bg-[var(--color-brand-teal)]/15 text-[var(--color-brand-teal)] hover:bg-[var(--color-brand-teal)]/25'
+            : 'border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]'
+          } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+        title={workspacePath ? `Workspace: ${workspacePath}` : 'Select Workspace'}
+      >
+        <FolderOpen size={12} />
+        <span className="max-w-[180px] truncate">
+          {workspacePath ? `Workspace: ${workspacePath.split(/[/\\]/).pop()}` : 'Select Workspace'}
+        </span>
+      </button>
 
-        {/* Dropdown Menu */}
-        {showContextMenu && (
-          <div className="absolute bottom-full mb-2 -right-4 bg-[var(--color-card-elevated)] border border-[var(--color-border)] rounded-[var(--radius-xl)] shadow-[var(--shadow-glass)] overflow-hidden min-w-[200px] animate-in fade-in slide-in-from-bottom-2 duration-[var(--duration-fast)] z-50">
-            {/* Select Workspace */}
-            <button
-              onClick={() => {
-                onSelectFolder()
-                setShowContextMenu(false)
-              }}
-              className="w-full flex items-center gap-3 px-4 py-3 text-[var(--text-sm)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface)] hover:text-[var(--color-primary)] transition-colors"
-            >
-              <FolderOpen
-                size={16}
-                className={workspacePath ? 'text-[var(--color-brand-teal)]' : 'text-[var(--color-text-muted)]'}
-              />
-              <div className="flex flex-col items-start">
-                <span className="font-[var(--font-weight-medium)]">Select Workspace</span>
-                {workspacePath && (
-                  <span className="text-[10px] text-[var(--color-brand-teal)]/70 max-w-[160px] truncate">
-                    {workspacePath.split(/[/\\]/).pop()}
-                  </span>
-                )}
-              </div>
-            </button>
-            <div className="border-t border-[var(--color-border)]" />
-            {/* Select Files */}
-            <button
-              onClick={() => {
-                fileInputRef.current?.click()
-                setShowContextMenu(false)
-              }}
-              className="w-full flex items-center gap-3 px-4 py-3 text-[var(--text-sm)] text-[var(--color-text-primary)] hover:bg-[var(--color-surface)] hover:text-[var(--color-primary)] transition-colors"
-            >
-              <FileIcon
-                size={16}
-                className={hasAttachments ? 'text-[var(--color-success)]' : 'text-[var(--color-text-muted)]'}
-              />
-              <span className="font-[var(--font-weight-medium)]">Select Files</span>
-            </button>
-          </div>
-        )}
-      </div>
+      <button
+        id="attachment-select-button"
+        data-testid="attachment-select-button"
+        type="button"
+        onClick={() => fileInputRef.current?.click()}
+        disabled={disabled}
+        className={`p-2 mb-[1px] rounded-[var(--radius-lg)] transition-all h-[44px] w-[36px] flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] ${hasAttachments
+            ? 'bg-[var(--color-success)]/20 text-[var(--color-success)] hover:bg-[var(--color-success)]/30'
+            : 'bg-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-surface)]'
+          } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+        title="Select Files"
+      >
+        <Paperclip size={18} />
+      </button>
+
+      <button
+        id="workspace-auto-file-write-approval-toggle"
+        data-testid="workspace-auto-file-write-approval-toggle"
+        type="button"
+        aria-pressed={fileWriteAutoApprove}
+        onClick={onToggleFileWriteAutoApprove}
+        disabled={disabled}
+        className={`inline-flex h-[36px] items-center gap-1.5 rounded-[var(--radius-lg)] border px-2 text-[10px] font-semibold tracking-wide transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] ${fileWriteAutoApprove
+            ? 'border-emerald-500/40 bg-emerald-500/15 text-emerald-300 hover:bg-emerald-500/25'
+            : 'border-amber-500/40 bg-amber-500/15 text-amber-300 hover:bg-amber-500/25'
+          } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+        title={fileWriteAutoApprove ? 'Auto File Write Approval: ON' : 'Auto File Write Approval: OFF'}
+      >
+        {fileWriteAutoApprove ? <ShieldCheck size={12} /> : <ShieldAlert size={12} />}
+        <span>Auto File Write Approval: {fileWriteAutoApprove ? 'ON' : 'OFF'}</span>
+      </button>
 
       {/* Headless Toggle */}
       <button

--- a/src/renderer/src/components/settings/McpPreferencesPanel.tsx
+++ b/src/renderer/src/components/settings/McpPreferencesPanel.tsx
@@ -9,7 +9,9 @@ export const McpPreferencesPanel: React.FC = () => {
         playwrightHeadless, 
         setPlaywrightHeadless,
         fileSystemSafeMode,
-        setFileSystemSafeMode
+        setFileSystemSafeMode,
+        fileSystemAutoApprove,
+        setFileSystemAutoApprove
     } = useSettingsStore()
 
     const browsers: { value: PlaywrightBrowserType; label: string }[] = [
@@ -90,7 +92,7 @@ export const McpPreferencesPanel: React.FC = () => {
                             Safe Mode (Shadow Writes)
                         </label>
                         <p className="text-xs text-muted-foreground">
-                            When enabled, the agent cannot write to files directly. Changes are staged in a temporary area and require your approval.
+                            When enabled, user-facing file edits are staged in a temporary area and require your approval. Internal AI-Worker tracking files (like <code>.ai-worker/tasks.json</code>) are written automatically.
                         </p>
                     </div>
                     <input
@@ -98,6 +100,21 @@ export const McpPreferencesPanel: React.FC = () => {
                         className="toggle toggle-success"
                         checked={fileSystemSafeMode}
                         onChange={(e) => setFileSystemSafeMode(e.target.checked)}
+                    />
+                </div>
+
+                <div className="flex items-center justify-between space-x-2 border rounded-md p-3">
+                    <div className="space-y-0.5">
+                        <label className="text-sm font-medium text-foreground">Auto-Approve Writes</label>
+                        <p className="text-xs text-muted-foreground">
+                            Automatically commit staged writes without showing the approval queue.
+                        </p>
+                    </div>
+                    <input
+                        type="checkbox"
+                        className="toggle toggle-success"
+                        checked={fileSystemAutoApprove}
+                        onChange={(e) => setFileSystemAutoApprove(e.target.checked)}
                     />
                 </div>
             </div>

--- a/src/renderer/src/components/settings/McpPreferencesPanel.tsx
+++ b/src/renderer/src/components/settings/McpPreferencesPanel.tsx
@@ -92,7 +92,7 @@ export const McpPreferencesPanel: React.FC = () => {
                             Safe Mode (Shadow Writes)
                         </label>
                         <p className="text-xs text-muted-foreground">
-                            When enabled, user-facing file edits are staged in a temporary area and require your approval. Internal AI-Worker tracking files (like <code>.ai-worker/tasks.json</code>) are written automatically.
+                            When enabled, user-facing file edits are staged in a temporary area and require your approval. Internal AI-Worker tracking files (under <code>~/.ai-worker/system-workspace</code>) are written automatically.
                         </p>
                     </div>
                     <input

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -49,6 +49,7 @@ interface ElectronAPI {
     app: {
         getVersion: () => Promise<string>
         getName: () => Promise<string>
+        getHomePath: () => Promise<string>
         selectFolder: () => Promise<string | null>
     }
 
@@ -67,7 +68,7 @@ interface ElectronAPI {
     }
 
     fs: {
-        getPendingChanges: () => Promise<Array<{
+        getPendingChanges: (sessionId?: string) => Promise<Array<{
             id: string
             originalPath: string
             shadowPath: string

--- a/src/renderer/src/global.d.ts
+++ b/src/renderer/src/global.d.ts
@@ -32,6 +32,7 @@ interface ElectronAPI {
     app: {
         getVersion: () => Promise<string>
         getName: () => Promise<string>
+        getHomePath: () => Promise<string>
         selectFolder: () => Promise<string | null>
         getMissingDependencies: () => Promise<any[]>
         getAllDependencies: () => Promise<any[]>

--- a/src/renderer/src/hooks/useAgent.ts
+++ b/src/renderer/src/hooks/useAgent.ts
@@ -38,6 +38,7 @@ import { useSettingsStore } from "../stores/settingsStore";
 import { type LLMMessage } from "../lib/types";
 import { resolveWhatsAppTarget, setWhatsAppTyping, setWhatsAppPaused, getWhatsAppSystemPrompt, sendWhatsAppResponse, resolveWhatsAppMessageToLLM } from "../lib/whatsapp-integration";
 import { buildAttachmentLLMParts } from "../lib/media-utils";
+import { executeToolCall } from "../lib/mcp";
 
 const LOCAL_PREFERENCE_MEMORY_KEY = "ai_worker_local_preferences_v1";
 
@@ -211,6 +212,7 @@ export function useAgent(): UseAgentReturn {
             // condition if the user disconnects mid-run (the finally call would return null,
             // leaving the typing indicator stuck on the personal phone).
             const targetJid = resolveWhatsAppTarget(content);
+            let runtime: { getAssignedTabId?: () => number | undefined } | null = null;
 
             try {
                 // ── Step 1: Reconstruct LLM message history ────────────────────────
@@ -278,10 +280,13 @@ export function useAgent(): UseAgentReturn {
                 }
 
                 // ── Step 4: Instantiate the agent ──────────────────────────────────
-                const runtime = new AgentRuntime(
+                runtime = new AgentRuntime(
                     {
                         activeSessionId: originSessionId,
                         workspacePath: activeSession?.workspacePath,
+                        // Preserve undefined so FileSystemService can fall back to
+                        // global mcpFileSystem.autoApprove when no session override exists.
+                        fileWriteAutoApprove: activeSession?.fileWriteAutoApprove,
                         settings: settingsForLLM,
                         isHeadless,
                         // The abort signal is scoped to THIS session only.
@@ -485,15 +490,22 @@ export function useAgent(): UseAgentReturn {
                 const existingPlan = store.sessions.find(s => s.id === originSessionId)?.plan;
                 store.updateSessionProgress(originSessionId, undefined, undefined, existingPlan);
 
-                // Do NOT force-close the browser on every prompt completion.
-                // BrowserManager already has an idle timeout and this eager close
-                // causes repeated relaunch/SingletonSocket cleanup thrash.
-                // Keep warm when no active sessions remain; close happens via idle timer.
+                // Close only the dedicated tab owned by this agent run.
+                // Keep the browser/context warm for other sessions and idle-timeout strategy.
+                const ownedTabId = runtime?.getAssignedTabId?.();
+                if (ownedTabId !== undefined) {
+                    try {
+                        await executeToolCall("close_tab", { tabId: ownedTabId, force: true });
+                    } catch (e) {
+                        console.warn(`[useAgent] Failed to close owned tab ${ownedTabId}:`, e);
+                    }
+                }
+
                 const currentProcessingCount = store._processingSessions.size;
                 if (currentProcessingCount === 0) {
-                    console.log('[useAgent] No active sessions. Leaving browser warm; idle timer will close it.');
+                    console.log('[useAgent] No active sessions. Browser stays warm; idle timer will close process if unused.');
                 } else {
-                    console.log(`[useAgent] 🕒 Deferring browser shutdown. ${currentProcessingCount} sessions still active.`);
+                    console.log(`[useAgent] 🕒 Session complete. ${currentProcessingCount} sessions still active; browser remains available.`);
                 }
             }
         },

--- a/src/renderer/src/lib/agent-runtime.ts
+++ b/src/renderer/src/lib/agent-runtime.ts
@@ -406,7 +406,7 @@ export class AgentRuntime implements IAgentClient {
           console.log('[AgentRuntime] Recovered execution plan from tasks.json');
 
           // Sync recovered plan to tasks.json to ensure file is up-to-date
-          import('./task-manager').then(m => m.syncPlanToFile(this.options.workspacePath, this.executionPlan!));
+          this._persistExecutionPlanToInternalFile();
         }
       } catch (e) {
         console.warn('[AgentRuntime] Failed to recover tasks.json:', e);
@@ -497,6 +497,7 @@ export class AgentRuntime implements IAgentClient {
           // onPlanUpdate: Bridge orchestration plan → session.plan → SubTaskChecklist
           (plan) => {
             this.executionPlan = plan;
+            this._persistExecutionPlanToInternalFile();
             this._emitProgress(this._lastProgressPct);
           }
         );
@@ -524,6 +525,7 @@ export class AgentRuntime implements IAgentClient {
           // plan=undefined to onProgressUpdate, and the checklist never renders.
           (plan) => {
             this.executionPlan = plan;
+            this._persistExecutionPlanToInternalFile();
             this._emitProgress(this._lastProgressPct);
           }
         );
@@ -732,6 +734,7 @@ export class AgentRuntime implements IAgentClient {
         if (call.name === "create_execution_plan") {
           const { result, plan } = this.specialHandlers.handleCreateExecutionPlan(call.arguments);
           this.executionPlan = plan;
+          this._persistExecutionPlanToInternalFile();
           resultStr = result;
         } else if (call.name === "scan_page_accessibility") {
           resultStr = await this.specialHandlers.handleScanPageAccessibility();
@@ -744,7 +747,10 @@ export class AgentRuntime implements IAgentClient {
             resultStr = "Nested delegation is disabled inside sub-agents. Complete the current sub-task directly.";
           } else {
             const { result, planUpdate } = await this.specialHandlers.handleDelegateSubTask(call.arguments, this.executionPlan);
-            if (planUpdate) this.executionPlan = planUpdate;
+            if (planUpdate) {
+              this.executionPlan = planUpdate;
+              this._persistExecutionPlanToInternalFile();
+            }
             resultStr = result;
           }
         } else {
@@ -929,6 +935,21 @@ export class AgentRuntime implements IAgentClient {
     }
     // Sending undefined for progress clears the bar (matches useAgent.ts finally-block behaviour)
     this.options.onProgressUpdate(clamped === 100 ? undefined : clamped, clamped === 100 ? undefined : eta, this.executionPlan ?? undefined);
+  }
+
+  /**
+   * Persists the current execution plan to `.ai-worker/tasks.json` via the
+   * internal IPC writer (bypasses staged fs_write approvals).
+   */
+  private _persistExecutionPlanToInternalFile(): void {
+    if (this.options.isSubAgent) return;
+    if (!this.options.workspacePath || !this.executionPlan) return;
+
+    import("./task-manager")
+      .then((m) => m.syncPlanToFile(this.options.workspacePath, this.executionPlan))
+      .catch((error) => {
+        console.warn("[AgentRuntime] Failed to persist execution plan:", error);
+      });
   }
 
   // ── Private: Helpers ───────────────────────────────────────────────────────

--- a/src/renderer/src/lib/agent-runtime.ts
+++ b/src/renderer/src/lib/agent-runtime.ts
@@ -27,8 +27,8 @@
 import { chat } from "./llm";
 import { LLMMessage, LLMTool, ServerInfo, type LLMResponse } from "./types";
 import { pruneContext } from "./dcp";
-import { getAllTools, getServers } from "./mcp";
-import { CLIENT_TOOLS } from "./client-tools";
+import { executeToolCall, getAllTools, getServers, parseTabIdFromResult } from "./mcp";
+import { CLIENT_TOOLS, STATEFUL_BROWSER_TOOLS } from "./client-tools";
 import type { IAgentClient } from "./agent/IAgentClient";
 import {
   initializeSessionState,
@@ -302,6 +302,16 @@ function shouldPreferDirectAnswer(prompt: string): boolean {
   return knowledgeQuestion;
 }
 
+function isBrowserToolName(toolName: string): boolean {
+  return (
+    STATEFUL_BROWSER_TOOLS.includes(toolName) ||
+    toolName.startsWith("playwright_") ||
+    toolName.startsWith("browser_")
+  );
+}
+
+const TAB_MANAGEMENT_TOOLS = new Set(["new_tab", "switch_tab", "close_tab", "get_tabs"]);
+
 export class AgentRuntime implements IAgentClient {
   private messages: LLMMessage[] = [];
   private options: AgentRuntimeOptions;
@@ -322,6 +332,8 @@ export class AgentRuntime implements IAgentClient {
   private _estimatedContextBytes = 0;
   /** Counter to trigger periodic full context resync */
   private _contextResyncCounter = 0;
+  /** Dedicated tab assigned to this runtime for browser-tool isolation */
+  private activeTabId: number | undefined;
 
   constructor(options: AgentRuntimeOptions, initialHistory: LLMMessage[] = []) {
     this.options = options;
@@ -336,6 +348,7 @@ export class AgentRuntime implements IAgentClient {
     }
 
     this.maxIterations = options.isSubAgent ? 15 : 50;
+    this.activeTabId = options.tabId;
     if (options.taskCategory) this.taskCategory = options.taskCategory;
 
     if (options.taskCategory) {
@@ -351,6 +364,30 @@ export class AgentRuntime implements IAgentClient {
       (msg) => this.addMessage(msg),
       () => this._makeSubAgentFactory()
     );
+  }
+
+  public getAssignedTabId(): number | undefined {
+    return this.activeTabId;
+  }
+
+  private async ensureDedicatedTabForBrowserTool(toolName: string): Promise<void> {
+    if (this.options.isHeadless) return;
+    if (!isBrowserToolName(toolName)) return;
+    if (TAB_MANAGEMENT_TOOLS.has(toolName)) return;
+    if (this.activeTabId !== undefined) return;
+
+    try {
+      const tabResult = await executeToolCall("new_tab", { url: "about:blank" });
+      const tabId = parseTabIdFromResult(tabResult);
+      if (tabId !== undefined) {
+        this.activeTabId = tabId;
+        console.log(`[AgentRuntime] Assigned dedicated tab ${tabId} to agent run`);
+      } else {
+        console.warn("[AgentRuntime] Could not parse tabId from new_tab result");
+      }
+    } catch (e) {
+      console.warn("[AgentRuntime] Failed to provision dedicated tab for browser tool", e);
+    }
   }
 
   async chat(
@@ -396,7 +433,7 @@ export class AgentRuntime implements IAgentClient {
       if (parentContextMsg) this.messages.push(parentContextMsg);
     }
 
-    // ── Check tasks.json for crash recovery ────────────────────────────────
+    // ── Check internal tasks.json for crash recovery ───────────────────────
     if (!this.executionPlan && !this.options.isSubAgent && this.options.workspacePath) {
       try {
         const electron = (await import('./electron')).default;
@@ -755,14 +792,23 @@ export class AgentRuntime implements IAgentClient {
           }
         } else {
           try {
+            await this.ensureDedicatedTabForBrowserTool(call.name);
             const rawResult = await executeWithSelfHealing(
               call.name,
               call.arguments as Record<string, unknown>,
-              this.options.tabId,
+              this.activeTabId,
               this.options.workspacePath,
+              this.options.activeSessionId,
+              this.options.fileWriteAutoApprove,
               this.options.signal,
               this.options.isHeadless
             );
+            if (call.name === "new_tab") {
+              const newTabId = parseTabIdFromResult(rawResult as { result: unknown });
+              if (newTabId !== undefined) {
+                this.activeTabId = newTabId;
+              }
+            }
             const { resultStr: formatted, isError } = formatToolResult(call.name, rawResult);
             resultStr = formatted;
             consecutiveErrors = isError ? consecutiveErrors + 1 : 0;
@@ -938,7 +984,8 @@ export class AgentRuntime implements IAgentClient {
   }
 
   /**
-   * Persists the current execution plan to `.ai-worker/tasks.json` via the
+   * Persists the current execution plan to AI-Worker's hidden internal
+   * workspace (`~/.ai-worker/system-workspace/.../tasks.json`) via the
    * internal IPC writer (bypasses staged fs_write approvals).
    */
   private _persistExecutionPlanToInternalFile(): void {
@@ -989,6 +1036,8 @@ export class AgentRuntime implements IAgentClient {
       const raw = await executeWithSelfHealing(
         "memory_search",
         { query, limit: 8 },
+        undefined,
+        undefined,
         undefined,
         undefined,
         this.options.signal,

--- a/src/renderer/src/lib/agent/ToolExecutionService.ts
+++ b/src/renderer/src/lib/agent/ToolExecutionService.ts
@@ -235,6 +235,8 @@ ${recentResults.length > 0
  * @param args - The tool arguments.
  * @param tabId - If set, inject as `args.tabId` for browser tools (tab isolation).
  * @param workspacePath - If set, inject as `args.workspacePath` for fs tools.
+ * @param activeSessionId - If set, inject as internal `_sessionId` for fs tools.
+ * @param fileWriteAutoApprove - Per-session override injected into `fs_write_file`.
  * @param signal - AbortSignal to cancel execution.
  * @returns `{ result, error }` — never throws (errors are returned as strings).
  */
@@ -243,10 +245,23 @@ export async function executeWithSelfHealing(
     args: Record<string, unknown>,
     tabId: number | undefined,
     workspacePath: string | undefined,
+    activeSessionId: string | undefined,
+    fileWriteAutoApprove: boolean | undefined,
     signal: AbortSignal | undefined,
     isHeadless?: boolean
 ): Promise<{ result: unknown; error?: string }> {
-    return _executeWithRetry(name, args, tabId, workspacePath, signal, isHeadless, 1, Date.now());
+    return _executeWithRetry(
+        name,
+        args,
+        tabId,
+        workspacePath,
+        activeSessionId,
+        fileWriteAutoApprove,
+        signal,
+        isHeadless,
+        1,
+        Date.now()
+    );
 }
 
 async function _executeWithRetry(
@@ -254,6 +269,8 @@ async function _executeWithRetry(
     args: Record<string, unknown>,
     tabId: number | undefined,
     workspacePath: string | undefined,
+    activeSessionId: string | undefined,
+    fileWriteAutoApprove: boolean | undefined,
     signal: AbortSignal | undefined,
     isHeadless: boolean | undefined,
     attempt: number,
@@ -285,8 +302,14 @@ async function _executeWithRetry(
         }
 
         // ── Workspace security: inject workspacePath for filesystem tools ─────────
-        if (name.startsWith("fs_") && workspacePath) {
-            args = { ...args, workspacePath };
+        if (name.startsWith("fs_")) {
+            const internalFsArgs: Record<string, unknown> = {};
+            if (workspacePath) internalFsArgs.workspacePath = workspacePath;
+            if (activeSessionId) internalFsArgs._sessionId = activeSessionId;
+            if (name === "fs_write_file" && typeof fileWriteAutoApprove === "boolean") {
+                internalFsArgs._sessionAutoApprove = fileWriteAutoApprove;
+            }
+            args = { ...args, ...internalFsArgs };
         }
 
         // ── Execute via Lane Manager ──────────────────────────────────────────────
@@ -335,7 +358,18 @@ async function _executeWithRetry(
                 console.log(`[ToolExecutionService] Context destroyed in ${name}. Retrying in 1s...`);
                 await delay(1000);
                 if (signal?.aborted) return { result: null, error: "Aborted by user" };
-                return _executeWithRetry(name, args, tabId, workspacePath, signal, isHeadless, attempt + 1, startTime);
+                return _executeWithRetry(
+                    name,
+                    args,
+                    tabId,
+                    workspacePath,
+                    activeSessionId,
+                    fileWriteAutoApprove,
+                    signal,
+                    isHeadless,
+                    attempt + 1,
+                    startTime
+                );
             }
 
             // ── Protocol errors: do NOT retry at this layer (Issue #2) ────────────
@@ -354,14 +388,36 @@ async function _executeWithRetry(
 
             if (errorStr.includes("Element is not attached") || errorStr.includes("Node is detached")) {
                 console.log(`[ToolExecutionService] Stale element in ${name}. Retrying immediately...`);
-                return _executeWithRetry(name, args, tabId, workspacePath, signal, isHeadless, attempt + 1, startTime);
+                return _executeWithRetry(
+                    name,
+                    args,
+                    tabId,
+                    workspacePath,
+                    activeSessionId,
+                    fileWriteAutoApprove,
+                    signal,
+                    isHeadless,
+                    attempt + 1,
+                    startTime
+                );
             }
 
             if (errorStr.includes("Lane timeout")) {
                 console.log(`[ToolExecutionService] Lane timeout for ${name} (attempt ${attempt}). Retrying in 2s...`);
                 await delay(2000);
                 if (signal?.aborted) return { result: null, error: "Aborted by user" };
-                return _executeWithRetry(name, args, tabId, workspacePath, signal, isHeadless, attempt + 1, startTime);
+                return _executeWithRetry(
+                    name,
+                    args,
+                    tabId,
+                    workspacePath,
+                    activeSessionId,
+                    fileWriteAutoApprove,
+                    signal,
+                    isHeadless,
+                    attempt + 1,
+                    startTime
+                );
             }
 
             if (errorStr.includes("Timeout") && args.timeout && typeof args.timeout === "number") {
@@ -371,6 +427,8 @@ async function _executeWithRetry(
                     { ...args, timeout: args.timeout * 2 },
                     tabId,
                     workspacePath,
+                    activeSessionId,
+                    fileWriteAutoApprove,
                     signal,
                     isHeadless,
                     attempt + 1,
@@ -386,7 +444,18 @@ async function _executeWithRetry(
                 console.log(`[ToolExecutionService] Network error in ${name}. Retrying in 2s...`);
                 await delay(2000);
                 if (signal?.aborted) return { result: null, error: "Aborted by user" };
-                return _executeWithRetry(name, args, tabId, workspacePath, signal, isHeadless, attempt + 1, startTime);
+                return _executeWithRetry(
+                    name,
+                    args,
+                    tabId,
+                    workspacePath,
+                    activeSessionId,
+                    fileWriteAutoApprove,
+                    signal,
+                    isHeadless,
+                    attempt + 1,
+                    startTime
+                );
             }
 
             if (
@@ -397,7 +466,18 @@ async function _executeWithRetry(
                 console.log(`[ToolExecutionService] Browser context lost in ${name}. Retrying in 1s...`);
                 await delay(1000);
                 if (signal?.aborted) return { result: null, error: "Aborted by user" };
-                return _executeWithRetry(name, args, tabId, workspacePath, signal, isHeadless, attempt + 1, startTime);
+                return _executeWithRetry(
+                    name,
+                    args,
+                    tabId,
+                    workspacePath,
+                    activeSessionId,
+                    fileWriteAutoApprove,
+                    signal,
+                    isHeadless,
+                    attempt + 1,
+                    startTime
+                );
             }
 
             if (
@@ -411,6 +491,8 @@ async function _executeWithRetry(
                     { ...args, timeout: ((args.timeout as number) || 5000) * 1.5 },
                     tabId,
                     workspacePath,
+                    activeSessionId,
+                    fileWriteAutoApprove,
                     signal,
                     isHeadless,
                     attempt + 1,
@@ -425,6 +507,8 @@ async function _executeWithRetry(
                     { ...args, timeout: ((args.timeout as number) || 30000) * 1.5 },
                     tabId,
                     workspacePath,
+                    activeSessionId,
+                    fileWriteAutoApprove,
                     signal,
                     isHeadless,
                     attempt + 1,

--- a/src/renderer/src/lib/agent/types.ts
+++ b/src/renderer/src/lib/agent/types.ts
@@ -48,6 +48,12 @@ export interface AgentRuntimeOptions {
     workspacePath?: string;
 
     /**
+     * Per-session override for filesystem write approval.
+     * When true, fs_write_file bypasses staging for this chat session only.
+     */
+    fileWriteAutoApprove?: boolean;
+
+    /**
      * LLM provider configuration (API keys, model names, base URLs).
      * Typed as `any` to avoid coupling to the settings store shape.
      * In Phase 3, this moves to the backend — the client sends only a session token.

--- a/src/renderer/src/lib/electron.ts
+++ b/src/renderer/src/lib/electron.ts
@@ -46,6 +46,14 @@ export const electron = {
         return null
     },
 
+    // Get user home path
+    getHomePath: async (): Promise<string> => {
+        if (isElectron() && window.electron?.app?.getHomePath) {
+            return await window.electron.app.getHomePath()
+        }
+        return ''
+    },
+
     // MCP operations
     mcp: {
         connect: async (serverConfig: unknown) => {
@@ -169,9 +177,9 @@ export const electron = {
 
     // FS operations
     fs: {
-        getPendingChanges: async () => {
+        getPendingChanges: async (sessionId?: string) => {
             if (isElectron() && window.electron?.fs) {
-                return await window.electron.fs.getPendingChanges()
+                return await window.electron.fs.getPendingChanges(sessionId)
             }
             return []
         },

--- a/src/renderer/src/lib/llm/prompts.ts
+++ b/src/renderer/src/lib/llm/prompts.ts
@@ -79,7 +79,7 @@ ${userContext}
 
 ${workspacePath ? `ACTIVE WORKSPACE: ${workspacePath}
 All filesystem operations (fs_*) MUST be performed within this directory.` : `WORKSPACE NOT SELECTED: 
-No workspace folder is set. For operations that CREATE or WRITE files (fs_write, fs_mkdir, etc.), ask the user to select a workspace folder using the folder icon in the UI.
+No workspace folder is set. For ANY filesystem operation (fs_read, fs_write, fs_list_directory, etc.), ask the user to select a workspace folder using the folder icon in the UI.
 IMPORTANT: If the user has attached a file to this message, READ it immediately using convert_to_markdown — attached files do NOT require a workspace.`}
 
 AVAILABLE TOOLS (${toolCount}):
@@ -232,7 +232,7 @@ ${workspacePath ? `ACTIVE WORKSPACE: ${workspacePath}
 All filesystem operations (fs_*) MUST be performed within this directory.
 You can use relative paths (e.g. "src/file.ts") which will be automatically resolved.
 Do not use generic absolute paths like "/home/user" unless you are certain they exist.` : `WORKSPACE NOT SELECTED: 
-No workspace folder is set. For operations that CREATE or WRITE files (fs_write, fs_mkdir, etc.), ask the user to select a workspace folder via the folder icon in the UI.
+No workspace folder is set. For ANY filesystem operation (fs_read, fs_write, fs_list_directory, etc.), ask the user to select a workspace folder via the folder icon in the UI.
 IMPORTANT: If the user has attached a file, READ it immediately using convert_to_markdown(uri="/absolute/path/...") — attached files do NOT require a workspace to be read.`}
 
 # RESPONSE FORMAT (CRITICAL)

--- a/src/renderer/src/lib/mcp.ts
+++ b/src/renderer/src/lib/mcp.ts
@@ -105,6 +105,91 @@ function ensureRecord(args: Record<string, unknown> | null | undefined): Record<
   return args || {};
 }
 
+function isAbsolutePath(value: string): boolean {
+  return value.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(value);
+}
+
+function normalizeAbsoluteFsPath(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  let normalized = trimmed.replace(/\\/g, '/');
+  let root = '';
+
+  if (/^[a-zA-Z]:\//.test(normalized)) {
+    root = normalized.slice(0, 2).toLowerCase();
+    normalized = normalized.slice(2);
+  } else if (normalized.startsWith('/')) {
+    root = '/';
+  } else {
+    return null;
+  }
+
+  const stack: string[] = [];
+  for (const part of normalized.split('/')) {
+    if (!part || part === '.') continue;
+    if (part === '..') {
+      if (stack.length > 0) stack.pop();
+      continue;
+    }
+    stack.push(part);
+  }
+
+  if (root === '/') return `/${stack.join('/')}`;
+  return stack.length > 0 ? `${root}/${stack.join('/')}` : `${root}/`;
+}
+
+function resolveFsPath(baseAbsolutePath: string, targetPath: string): string | null {
+  const normalizedBase = normalizeAbsoluteFsPath(baseAbsolutePath);
+  if (!normalizedBase) return null;
+
+  const rawTarget = targetPath.trim();
+  if (!rawTarget) return normalizedBase;
+
+  if (isAbsolutePath(rawTarget)) {
+    return normalizeAbsoluteFsPath(rawTarget);
+  }
+
+  const normalizedRelative = rawTarget.replace(/\\/g, '/');
+  let root = '';
+  let tail = '';
+
+  if (/^[a-zA-Z]:\//.test(normalizedBase)) {
+    root = normalizedBase.slice(0, 2).toLowerCase();
+    tail = normalizedBase.slice(2);
+  } else if (normalizedBase.startsWith('/')) {
+    root = '/';
+    tail = normalizedBase.slice(1);
+  } else {
+    return null;
+  }
+
+  const stack = tail.split('/').filter(Boolean);
+  for (const part of normalizedRelative.split('/')) {
+    if (!part || part === '.') continue;
+    if (part === '..') {
+      if (stack.length > 0) stack.pop();
+      continue;
+    }
+    stack.push(part);
+  }
+
+  if (root === '/') return `/${stack.join('/')}`;
+  return stack.length > 0 ? `${root}/${stack.join('/')}` : `${root}/`;
+}
+
+function isPathWithin(rootPath: string, targetPath: string): boolean {
+  const normalizedRoot = normalizeAbsoluteFsPath(rootPath);
+  const normalizedTarget = normalizeAbsoluteFsPath(targetPath);
+  if (!normalizedRoot || !normalizedTarget) return false;
+  const rootComparable = (normalizedRoot.replace(/\/+$/, '') || '/').toLowerCase();
+  const targetComparable = (normalizedTarget.replace(/\/+$/, '') || '/').toLowerCase();
+  return (
+    targetComparable === rootComparable ||
+    targetComparable.startsWith(`${rootComparable}/`)
+  );
+}
+
 // Execute a tool call with retry logic for connection errors
 
 // ── MCP Idle Disconnect Timers ──────────────────────────────────────────────────
@@ -194,39 +279,48 @@ export async function executeToolCall(
 
 
   if (toolName.startsWith('fs_')) {
-    // Block filesystem access when BOTH conditions are true:
-    //   (a) no workspace path has been set for this session, AND
-    //   (b) the target path itself is not already absolute.
-    // This allows: auto-set workspaces (from file attachment), absolute paths.
-    // This blocks:  relative paths with no workspace context.
     const wsPath = args?.workspacePath as string | undefined;
-    const targetPath = args?.path as string | undefined;
-    const targetIsAbsolute =
-      !!targetPath &&
-      (targetPath.startsWith('/') || !!targetPath.match(/^[a-zA-Z]:[\\/]/));
-
-    if (!wsPath && !targetIsAbsolute) {
+    if (!wsPath) {
       return {
         result: null,
-        error: 'WORKSPACE REQUIRED: Please select a workspace folder using the folder icon in the UI before performing filesystem operations.'
+        error: 'WORKSPACE REQUIRED: Select a workspace folder before using filesystem tools.'
+      };
+    }
+    const normalizedWorkspacePath = normalizeAbsoluteFsPath(wsPath);
+    if (!normalizedWorkspacePath) {
+      return {
+        result: null,
+        error: `WORKSPACE REQUIRED: Invalid workspace path '${wsPath}'.`
       };
     }
 
-    // Path traversal guard — only runs when a workspace boundary is defined.
-    if (wsPath && targetPath) {
-      const normalizedWs = wsPath.replace(/\\/g, '/').replace(/\/$/, '');
-      const normalizedTarget = targetPath.replace(/\\/g, '/');
-      if (!normalizedTarget.startsWith(normalizedWs)) {
+    const userHomePath = await electron.getHomePath();
+    if (!userHomePath || !isPathWithin(userHomePath, normalizedWorkspacePath)) {
+      return {
+        result: null,
+        error: `WORKSPACE REQUIRED: Workspace must be inside your user home folder (${userHomePath || 'unavailable'}).`
+      };
+    }
+    (args as Record<string, unknown>).workspacePath = normalizedWorkspacePath;
+
+    const rawTargetPath = args?.path as string | undefined;
+    if (rawTargetPath && rawTargetPath.trim() !== '') {
+      const resolvedTargetPath = resolveFsPath(normalizedWorkspacePath, rawTargetPath);
+      if (!resolvedTargetPath) {
         return {
           result: null,
-          error: `SECURITY VIOLATION: Access denied. Path '${targetPath}' is outside the active workspace '${wsPath}'.`
+          error: `SECURITY VIOLATION: Invalid path '${rawTargetPath}'.`
         };
       }
-    }
 
-    // Remove workspacePath from args before forwarding — tools don't expect it.
-    if (args && 'workspacePath' in args) {
-      delete (args as Record<string, unknown>).workspacePath;
+      if (!isPathWithin(normalizedWorkspacePath, resolvedTargetPath)) {
+        return {
+          result: null,
+          error: `SECURITY VIOLATION: Access denied. Path '${resolvedTargetPath}' is outside the active workspace '${normalizedWorkspacePath}'.`
+        };
+      }
+
+      (args as Record<string, unknown>).path = resolvedTargetPath;
     }
   }
 

--- a/src/renderer/src/lib/task-manager.ts
+++ b/src/renderer/src/lib/task-manager.ts
@@ -3,7 +3,7 @@ import electron from "./electron";
 
 /**
  * Syncs the internal ExecutionPlan to a JSON file 
- * in the user's workspace under `.ai-worker/tasks.json`.
+ * in AI-Worker's hidden internal system workspace (`~/.ai-worker/system-workspace/.../tasks.json`).
  * 
  * Bypasses Safe Mode so the user isn't prompted for every step.
  */

--- a/src/renderer/src/stores/chatStore.ts
+++ b/src/renderer/src/stores/chatStore.ts
@@ -43,6 +43,7 @@ export interface ChatSession {
     createdAt: number
     updatedAt: number
     workspacePath?: string   // Optional workspace folder for this chat session
+    fileWriteAutoApprove?: boolean // Per-session override; undefined => inherit global setting
     progress?: number
     eta?: number
     plan?: ExecutionPlan
@@ -101,6 +102,7 @@ interface ChatState {
     setActiveSession: (id: string) => void
     updateSessionTitle: (id: string, title: string) => void
     updateSessionWorkspace: (id: string, workspacePath: string) => void
+    setSessionFileWriteAutoApprove: (id: string, enabled: boolean | undefined) => void
     updateSessionProgress: (id: string, progress?: number, eta?: number, plan?: ExecutionPlan) => void
     setOfflineSpeech: (enabled: boolean) => void
 
@@ -279,6 +281,14 @@ export const useChatStore = create<ChatState>()(
                 set((state) => ({
                     sessions: state.sessions.map((s) =>
                         s.id === id ? { ...s, workspacePath, updatedAt: Date.now() } : s
+                    ),
+                }))
+            },
+
+            setSessionFileWriteAutoApprove: (id: string, enabled: boolean | undefined) => {
+                set((state) => ({
+                    sessions: state.sessions.map((s) =>
+                        s.id === id ? { ...s, fileWriteAutoApprove: enabled, updatedAt: Date.now() } : s
                     ),
                 }))
             },

--- a/src/renderer/src/stores/settingsStore.ts
+++ b/src/renderer/src/stores/settingsStore.ts
@@ -46,6 +46,7 @@ interface SettingsState {
 
     // MCP FileSystem settings
     fileSystemSafeMode: boolean
+    fileSystemAutoApprove: boolean
 
     // Sync State
     activeUserId: string | null
@@ -77,6 +78,7 @@ interface SettingsState {
     setPlaywrightBrowser: (browser: PlaywrightBrowserType) => void
     setPlaywrightHeadless: (headless: boolean) => void
     setFileSystemSafeMode: (enabled: boolean) => void
+    setFileSystemAutoApprove: (enabled: boolean) => void
 
     // Memory Settings
     memoryBackend: 'server-memory' | 'memento-mcp'
@@ -120,6 +122,7 @@ const defaultSettings = {
     playwrightBrowser: 'auto' as PlaywrightBrowserType, // Auto-detect based on OS
     playwrightHeadless: false, // Default to headed for user visibility
     fileSystemSafeMode: true, // Default to safe mode (shadow writes)
+    fileSystemAutoApprove: false, // Default: manual approval required
     memoryBackend: 'server-memory' as 'server-memory' | 'memento-mcp', // Default backend
     activeUserId: null,
     isSyncing: false,
@@ -193,6 +196,11 @@ export const useSettingsStore = create<SettingsState>()(
                 // Save to main process store for FileSystemService to read
                 const current = await electron.store.get<Record<string, unknown>>('mcpFileSystem') || {}
                 await electron.store.set('mcpFileSystem', { ...current, safeMode: enabled })
+            },
+            setFileSystemAutoApprove: async (enabled) => {
+                set({ fileSystemAutoApprove: enabled })
+                const current = await electron.store.get<Record<string, unknown>>('mcpFileSystem') || {}
+                await electron.store.set('mcpFileSystem', { ...current, autoApprove: enabled })
             },
             setMemoryBackend: async (backend) => {
                 set({ memoryBackend: backend })

--- a/tests/issues_repro_report.json
+++ b/tests/issues_repro_report.json
@@ -1,12 +1,12 @@
 {
-  "generatedAt": "2026-04-05T06:38:33.858Z",
+  "generatedAt": "2026-04-05T12:15:18.127Z",
   "suite": "issues_repro_e2e",
   "excludedIssue": "#15",
   "results": [
     {
       "issue": "#11",
       "status": "not_reproduced",
-      "finding": "guard active (writes=1, paused=true)"
+      "finding": "guard active (writes=2, paused=true)"
     },
     {
       "issue": "#13",
@@ -15,8 +15,8 @@
     },
     {
       "issue": "#14/#26",
-      "status": "inconclusive",
-      "finding": "no stable multi-context UI signal observed"
+      "status": "not_reproduced",
+      "finding": "multi-context output remained visible"
     },
     {
       "issue": "#12/#27",
@@ -51,7 +51,7 @@
   ],
   "summary": {
     "reproduced": 0,
-    "not_reproduced": 6,
-    "inconclusive": 3
+    "not_reproduced": 7,
+    "inconclusive": 2
   }
 }

--- a/tests/real_e2e_focus.cjs
+++ b/tests/real_e2e_focus.cjs
@@ -107,7 +107,7 @@ async function screenshot(window, name) {
 
   const electronApp = await electron.launch({
     executablePath: execPath,
-    args: [APP_PATH],
+    args: [APP_PATH, '--no-sandbox'],
     env: { ...env, NODE_ENV: 'production' },
     timeout: 120000,
   });

--- a/tests/real_e2e_test.cjs
+++ b/tests/real_e2e_test.cjs
@@ -396,6 +396,17 @@ async function rejectPendingWriteForPath(window, targetPath) {
     }, { targetPath });
 }
 
+async function hasPendingWriteForPath(window, targetPath) {
+    return await window.evaluate(async ({ targetPath }) => {
+        try {
+            const pending = await window.electron.fs.getPendingChanges();
+            return (pending || []).some((change) => change && change.originalPath === targetPath);
+        } catch {
+            return false;
+        }
+    }, { targetPath });
+}
+
 /**
  * Toggle "Detailed Visibility" mode in dev UI.
  * - true  => Detailed Visibility ON (dev internals visible)
@@ -1101,6 +1112,7 @@ async function setDetailedVisibility(window, enabled) {
                 const stagedWriteCalls = logsCount(/Executing tool: fs_write_file/i);
                 const stagedSignalSeen = logsContain(/File Write Paused|status["\\]*\s*:\s*["\\]*staged|STAGED for review/i);
                 const stagedFileExists = fs.existsSync(stagedPath);
+                const stagedPendingExists = await hasPendingWriteForPath(window, stagedPath);
 
                 // Clean staged queue entry to keep environment stable
                 await rejectPendingWriteForPath(window, stagedPath);
@@ -1142,7 +1154,7 @@ async function setDetailedVisibility(window, enabled) {
                 const passed =
                     !stagedResult.timedOut &&
                     stagedWriteCalls >= 1 &&
-                    stagedSignalSeen &&
+                    (stagedSignalSeen || stagedPendingExists) &&
                     !stagedFileExists &&
                     !autoResult.timedOut &&
                     autoWriteCalls >= 1 &&
@@ -1153,7 +1165,7 @@ async function setDetailedVisibility(window, enabled) {
                 recordResult(
                     'Critical 7: Filesystem Auto-Approve Toggle',
                     passed,
-                    `Staged mode -> timedOut=${stagedResult.timedOut}, calls=${stagedWriteCalls}, stagedSignal=${stagedSignalSeen}, fileExists=${stagedFileExists}. Auto-approve mode -> timedOut=${autoResult.timedOut}, calls=${autoWriteCalls}, autoSignal=${autoApproveSignal}, stagedSignal=${autoStagedSignal}, fileExists=${autoFileExists}, contentMatch=${autoContentMatches}`
+                    `Staged mode -> timedOut=${stagedResult.timedOut}, calls=${stagedWriteCalls}, stagedSignal=${stagedSignalSeen}, pendingExists=${stagedPendingExists}, fileExists=${stagedFileExists}. Auto-approve mode -> timedOut=${autoResult.timedOut}, calls=${autoWriteCalls}, autoSignal=${autoApproveSignal}, stagedSignal=${autoStagedSignal}, fileExists=${autoFileExists}, contentMatch=${autoContentMatches}`
                 );
             }
         }

--- a/tests/real_e2e_test.cjs
+++ b/tests/real_e2e_test.cjs
@@ -381,10 +381,36 @@ async function setFileSystemSettings(window, safeMode, autoApprove) {
     await window.waitForTimeout(300);
 }
 
+async function isSessionAutoApproveEnabled(window) {
+    const toggle = window.locator('[data-testid="workspace-auto-file-write-approval-toggle"]');
+    await toggle.first().waitFor({ state: 'visible', timeout: 15000 });
+    const pressed = await toggle.first().getAttribute('aria-pressed');
+    return pressed === 'true';
+}
+
+async function setSessionAutoApprove(window, enabled) {
+    const toggle = window.locator('[data-testid="workspace-auto-file-write-approval-toggle"]');
+    await toggle.first().waitFor({ state: 'visible', timeout: 15000 });
+    const current = await isSessionAutoApproveEnabled(window);
+    if (current !== enabled) {
+        await toggle.first().click();
+        await window.waitForTimeout(350);
+    }
+}
+
 async function rejectPendingWriteForPath(window, targetPath) {
     await window.evaluate(async ({ targetPath }) => {
         try {
-            const pending = await window.electron.fs.getPendingChanges();
+            const raw = window.localStorage.getItem('ai-worker-chat-v3');
+            let activeSessionId = 'default';
+            if (raw) {
+                const parsed = JSON.parse(raw);
+                activeSessionId =
+                    parsed?.state?.activeSessionId ||
+                    parsed?.activeSessionId ||
+                    'default';
+            }
+            const pending = await window.electron.fs.getPendingChanges(activeSessionId);
             for (const change of pending || []) {
                 if (change && change.originalPath === targetPath) {
                     await window.electron.fs.rejectChange(change.id);
@@ -399,7 +425,16 @@ async function rejectPendingWriteForPath(window, targetPath) {
 async function hasPendingWriteForPath(window, targetPath) {
     return await window.evaluate(async ({ targetPath }) => {
         try {
-            const pending = await window.electron.fs.getPendingChanges();
+            const raw = window.localStorage.getItem('ai-worker-chat-v3');
+            let activeSessionId = 'default';
+            if (raw) {
+                const parsed = JSON.parse(raw);
+                activeSessionId =
+                    parsed?.state?.activeSessionId ||
+                    parsed?.activeSessionId ||
+                    'default';
+            }
+            const pending = await window.electron.fs.getPendingChanges(activeSessionId);
             return (pending || []).some((change) => change && change.originalPath === targetPath);
         } catch {
             return false;
@@ -457,7 +492,7 @@ async function setDetailedVisibility(window, enabled) {
     try {
         electronApp = await electron.launch({
             executablePath: execPath,
-            args: [APP_PATH],
+            args: [APP_PATH, '--no-sandbox'],
             env: { ...env, NODE_ENV: 'production' },
             timeout: 120000
         });
@@ -1080,23 +1115,34 @@ async function setDetailedVisibility(window, enabled) {
         }
 
         // ══════════════════════════════════════════════════════════
-        //  CRITICAL 7: Filesystem auto-approve should bypass staging
-        //  Verifies both behaviors:
-        //    - safeMode=true + autoApprove=false => staged (no direct write)
-        //    - safeMode=true + autoApprove=true  => direct write
+        //  CRITICAL 7: Session-scoped workspace row controls + auto-approve toggle
+        //  Verifies:
+        //    - Workspace selector, file selector, and auto-approve toggle are visible
+        //    - OFF => staged (no direct write)
+        //    - ON  => direct write in same session
+        //    - New chat session starts with toggle OFF (session isolation)
         // ══════════════════════════════════════════════════════════
         if (shouldRunCritical(7)) {
             console.log('\n' + '─'.repeat(60));
-            console.log('📋 Critical 7: Filesystem Auto-Approve Toggle');
+            console.log('📋 Critical 7: Session Auto-Approve + Workspace Controls');
             console.log('─'.repeat(60));
             {
+                const sessionResetPath = `/tmp/ai-worker-e2e-session-reset-${Date.now()}.txt`;
                 const stagedPath = `/tmp/ai-worker-e2e-staged-${Date.now()}.txt`;
                 const autoApprovedPath = `/tmp/ai-worker-e2e-auto-approved-${Date.now()}.txt`;
                 const autoApprovedContent = `AUTO_APPROVE_OK_${Date.now()}`;
+                const sessionResetContent = `SESSION_RESET_CONTENT_${Date.now()}`;
 
-                // Part A: staging path (auto-approve OFF)
+                // Keep global defaults deterministic: safe mode ON, global auto-approve OFF.
                 await setFileSystemSettings(window, true, false);
+
+                // Part A: Session toggle OFF -> staging path.
                 await startNewChat(window);
+                const workspaceSelectorVisible = (await window.locator('[data-testid="workspace-select-button"]').count()) > 0;
+                const fileSelectorVisible = (await window.locator('[data-testid="attachment-select-button"]').count()) > 0;
+                const sessionToggleVisible = (await window.locator('[data-testid="workspace-auto-file-write-approval-toggle"]').count()) > 0;
+                const initialSessionAutoApprove = await isSessionAutoApproveEnabled(window);
+                await setSessionAutoApprove(window, false);
                 clearLogs();
 
                 const stagedResult = await sendPromptAndWait(
@@ -1119,9 +1165,9 @@ async function setDetailedVisibility(window, enabled) {
 
                 await screenshot(window, 'critical-07a-auto-approve-off');
 
-                // Part B: auto-approve path (auto-approve ON)
-                await setFileSystemSettings(window, true, true);
-                await startNewChat(window);
+                // Part B: same session toggle ON -> direct write.
+                await setSessionAutoApprove(window, true);
+                const sessionAutoApproveOn = await isSessionAutoApproveEnabled(window);
                 clearLogs();
 
                 const autoResult = await sendPromptAndWait(
@@ -1136,15 +1182,30 @@ async function setDetailedVisibility(window, enabled) {
 
                 const autoWriteCalls = logsCount(/Executing tool: fs_write_file/i);
                 const autoStagedSignal = logsContain(/status["\\]*\s*:\s*["\\]*staged|STAGED for review|File Write Paused/i);
-                const autoApproveSignal = logsContain(/written_auto_approved|File written with auto-approval/i);
+                const autoApproveSignal = logsContain(/written_session_auto_approved|File written with session auto-approval|written_auto_approved|File written with auto-approval/i);
                 const autoFileExists = fs.existsSync(autoApprovedPath);
                 const autoFileContent = autoFileExists ? fs.readFileSync(autoApprovedPath, 'utf8') : '';
                 const autoContentMatches = autoFileContent === autoApprovedContent;
 
                 await screenshot(window, 'critical-07b-auto-approve-on');
 
-                // Restore defaults for subsequent tests and manual usage
-                await setFileSystemSettings(window, true, false);
+                // Part C: new session should reset to OFF (session-scoped).
+                await startNewChat(window);
+                const sessionAutoApproveAfterNewSession = await isSessionAutoApproveEnabled(window);
+                clearLogs();
+                const sessionResetResult = await sendPromptAndWait(
+                    window,
+                    `Use fs_write_file to write exactly this absolute path: ${sessionResetPath}. Content must be exactly: ${sessionResetContent}`,
+                    {
+                        maxWaitS: 90,
+                        keywords: ['staged', 'approval', 'file write paused', 'review'],
+                        successLogPattern: /File Write Paused|status["\\]*\s*:\s*["\\]*staged|STAGED for review/i,
+                    }
+                );
+                const sessionResetStaged = logsContain(/File Write Paused|status["\\]*\s*:\s*["\\]*staged|STAGED for review/i);
+                const sessionResetFileExists = fs.existsSync(sessionResetPath);
+                const sessionResetPending = await hasPendingWriteForPath(window, sessionResetPath);
+                await rejectPendingWriteForPath(window, sessionResetPath);
 
                 // Cleanup created file
                 if (autoFileExists) {
@@ -1152,20 +1213,29 @@ async function setDetailedVisibility(window, enabled) {
                 }
 
                 const passed =
+                    workspaceSelectorVisible &&
+                    fileSelectorVisible &&
+                    sessionToggleVisible &&
+                    initialSessionAutoApprove === false &&
                     !stagedResult.timedOut &&
                     stagedWriteCalls >= 1 &&
                     (stagedSignalSeen || stagedPendingExists) &&
                     !stagedFileExists &&
+                    sessionAutoApproveOn &&
                     !autoResult.timedOut &&
                     autoWriteCalls >= 1 &&
                     autoFileExists &&
                     autoContentMatches &&
-                    !autoStagedSignal;
+                    !autoStagedSignal &&
+                    !sessionResetResult.timedOut &&
+                    sessionAutoApproveAfterNewSession === false &&
+                    (sessionResetStaged || sessionResetPending) &&
+                    !sessionResetFileExists;
 
                 recordResult(
-                    'Critical 7: Filesystem Auto-Approve Toggle',
+                    'Critical 7: Session Auto-Approve + Workspace Controls',
                     passed,
-                    `Staged mode -> timedOut=${stagedResult.timedOut}, calls=${stagedWriteCalls}, stagedSignal=${stagedSignalSeen}, pendingExists=${stagedPendingExists}, fileExists=${stagedFileExists}. Auto-approve mode -> timedOut=${autoResult.timedOut}, calls=${autoWriteCalls}, autoSignal=${autoApproveSignal}, stagedSignal=${autoStagedSignal}, fileExists=${autoFileExists}, contentMatch=${autoContentMatches}`
+                    `workspaceVisible=${workspaceSelectorVisible}, filesVisible=${fileSelectorVisible}, toggleVisible=${sessionToggleVisible}, initialOff=${initialSessionAutoApprove === false}, toggledOn=${sessionAutoApproveOn}, newSessionOff=${sessionAutoApproveAfterNewSession === false}. Staged mode -> timedOut=${stagedResult.timedOut}, calls=${stagedWriteCalls}, stagedSignal=${stagedSignalSeen}, pendingExists=${stagedPendingExists}, fileExists=${stagedFileExists}. Auto-approve mode -> timedOut=${autoResult.timedOut}, calls=${autoWriteCalls}, autoSignal=${autoApproveSignal}, stagedSignal=${autoStagedSignal}, fileExists=${autoFileExists}, contentMatch=${autoContentMatches}. Session reset -> timedOut=${sessionResetResult.timedOut}, staged=${sessionResetStaged}, pending=${sessionResetPending}, fileExists=${sessionResetFileExists}`
                 );
             }
         }

--- a/tests/real_e2e_test.cjs
+++ b/tests/real_e2e_test.cjs
@@ -1138,6 +1138,19 @@ async function setDetailedVisibility(window, enabled) {
 
                 // Part A: Session toggle OFF -> staging path.
                 await startNewChat(window);
+                
+                // Set /tmp as the session workspace to satisfy security guards
+                await window.evaluate(async (path) => {
+                    if (window.useChatStore) {
+                        const state = window.useChatStore.getState();
+                        if (state.activeSessionId) {
+                            state.updateSessionWorkspace(state.activeSessionId, path);
+                        }
+                    }
+                }, '/tmp');
+                
+                await window.waitForTimeout(500); // Wait for store/UI to settle
+
                 const workspaceSelectorVisible = (await window.locator('[data-testid="workspace-select-button"]').count()) > 0;
                 const fileSelectorVisible = (await window.locator('[data-testid="attachment-select-button"]').count()) > 0;
                 const sessionToggleVisible = (await window.locator('[data-testid="workspace-auto-file-write-approval-toggle"]').count()) > 0;

--- a/tests/real_e2e_test.cjs
+++ b/tests/real_e2e_test.cjs
@@ -29,7 +29,7 @@ const SELECTED_CRITICALS = (() => {
     const ids = raw
         .split(',')
         .map((part) => Number(part.trim()))
-        .filter((n) => Number.isInteger(n) && n >= 1 && n <= 6);
+        .filter((n) => Number.isInteger(n) && n >= 1 && n <= 7);
     return ids.length ? new Set(ids) : null;
 })();
 function shouldRunCritical(id) {
@@ -367,6 +367,33 @@ async function startNewChat(window) {
  */
 async function screenshot(window, name) {
     await window.screenshot({ path: path.join(SCREENSHOT_DIR, `${name}.png`) });
+}
+
+async function setFileSystemSettings(window, safeMode, autoApprove) {
+    await window.evaluate(async ({ safeMode, autoApprove }) => {
+        const current = (await window.electron.store.get('mcpFileSystem')) || {};
+        await window.electron.store.set('mcpFileSystem', {
+            ...current,
+            safeMode,
+            autoApprove
+        });
+    }, { safeMode, autoApprove });
+    await window.waitForTimeout(300);
+}
+
+async function rejectPendingWriteForPath(window, targetPath) {
+    await window.evaluate(async ({ targetPath }) => {
+        try {
+            const pending = await window.electron.fs.getPendingChanges();
+            for (const change of pending || []) {
+                if (change && change.originalPath === targetPath) {
+                    await window.electron.fs.rejectChange(change.id);
+                }
+            }
+        } catch {
+            // best-effort cleanup
+        }
+    }, { targetPath });
 }
 
 /**
@@ -1037,6 +1064,96 @@ async function setDetailedVisibility(window, enabled) {
                     'Critical 4: File Write Loop Safety',
                     completed && !infiniteLoopDetected,
                     `Completed: ${completed}. Timed out: ${result.timedOut}. Workspace guard: ${workspaceGuardSeen}. Assistant response: ${receivedAssistantResponse}. Infinite fs loop: ${infiniteLoopDetected}. fs_write references: ${repeatedFsWrite}`
+                );
+            }
+        }
+
+        // ══════════════════════════════════════════════════════════
+        //  CRITICAL 7: Filesystem auto-approve should bypass staging
+        //  Verifies both behaviors:
+        //    - safeMode=true + autoApprove=false => staged (no direct write)
+        //    - safeMode=true + autoApprove=true  => direct write
+        // ══════════════════════════════════════════════════════════
+        if (shouldRunCritical(7)) {
+            console.log('\n' + '─'.repeat(60));
+            console.log('📋 Critical 7: Filesystem Auto-Approve Toggle');
+            console.log('─'.repeat(60));
+            {
+                const stagedPath = `/tmp/ai-worker-e2e-staged-${Date.now()}.txt`;
+                const autoApprovedPath = `/tmp/ai-worker-e2e-auto-approved-${Date.now()}.txt`;
+                const autoApprovedContent = `AUTO_APPROVE_OK_${Date.now()}`;
+
+                // Part A: staging path (auto-approve OFF)
+                await setFileSystemSettings(window, true, false);
+                await startNewChat(window);
+                clearLogs();
+
+                const stagedResult = await sendPromptAndWait(
+                    window,
+                    `Use fs_write_file to write exactly this absolute path: ${stagedPath}. Content must be exactly: STAGED_TEST_CONTENT`,
+                    {
+                        maxWaitS: 90,
+                        keywords: ['staged', 'approval', 'file write paused', 'review'],
+                        successLogPattern: /File Write Paused|status["\\]*\s*:\s*["\\]*staged|STAGED for review/i,
+                    }
+                );
+
+                const stagedWriteCalls = logsCount(/Executing tool: fs_write_file/i);
+                const stagedSignalSeen = logsContain(/File Write Paused|status["\\]*\s*:\s*["\\]*staged|STAGED for review/i);
+                const stagedFileExists = fs.existsSync(stagedPath);
+
+                // Clean staged queue entry to keep environment stable
+                await rejectPendingWriteForPath(window, stagedPath);
+
+                await screenshot(window, 'critical-07a-auto-approve-off');
+
+                // Part B: auto-approve path (auto-approve ON)
+                await setFileSystemSettings(window, true, true);
+                await startNewChat(window);
+                clearLogs();
+
+                const autoResult = await sendPromptAndWait(
+                    window,
+                    `Use fs_write_file to write exactly this absolute path: ${autoApprovedPath}. Content must be exactly: ${autoApprovedContent}`,
+                    {
+                        maxWaitS: 90,
+                        keywords: ['written', 'saved', 'created', 'done', 'file'],
+                        successLogPattern: /written_auto_approved|File written with auto-approval|Executing tool: fs_write_file/i,
+                    }
+                );
+
+                const autoWriteCalls = logsCount(/Executing tool: fs_write_file/i);
+                const autoStagedSignal = logsContain(/status["\\]*\s*:\s*["\\]*staged|STAGED for review|File Write Paused/i);
+                const autoApproveSignal = logsContain(/written_auto_approved|File written with auto-approval/i);
+                const autoFileExists = fs.existsSync(autoApprovedPath);
+                const autoFileContent = autoFileExists ? fs.readFileSync(autoApprovedPath, 'utf8') : '';
+                const autoContentMatches = autoFileContent === autoApprovedContent;
+
+                await screenshot(window, 'critical-07b-auto-approve-on');
+
+                // Restore defaults for subsequent tests and manual usage
+                await setFileSystemSettings(window, true, false);
+
+                // Cleanup created file
+                if (autoFileExists) {
+                    try { fs.unlinkSync(autoApprovedPath); } catch { /* ignore */ }
+                }
+
+                const passed =
+                    !stagedResult.timedOut &&
+                    stagedWriteCalls >= 1 &&
+                    stagedSignalSeen &&
+                    !stagedFileExists &&
+                    !autoResult.timedOut &&
+                    autoWriteCalls >= 1 &&
+                    autoFileExists &&
+                    autoContentMatches &&
+                    !autoStagedSignal;
+
+                recordResult(
+                    'Critical 7: Filesystem Auto-Approve Toggle',
+                    passed,
+                    `Staged mode -> timedOut=${stagedResult.timedOut}, calls=${stagedWriteCalls}, stagedSignal=${stagedSignalSeen}, fileExists=${stagedFileExists}. Auto-approve mode -> timedOut=${autoResult.timedOut}, calls=${autoWriteCalls}, autoSignal=${autoApproveSignal}, stagedSignal=${autoStagedSignal}, fileExists=${autoFileExists}, contentMatch=${autoContentMatches}`
                 );
             }
         }

--- a/tests/regression_critical_checks.cjs
+++ b/tests/regression_critical_checks.cjs
@@ -408,6 +408,75 @@ function testRealE2EIdleGating() {
   assertIncludes(realSrc, 'successLogPattern: /Using deterministic local preference recall answer/i,', 'real-e2e');
 }
 
+function testWorkspaceSelectionAndInternalTaskTracking() {
+  const toolbarSrc = read('src/renderer/src/components/input/InputToolbar.tsx');
+  assertIncludes(toolbarSrc, 'data-testid="workspace-select-button"', 'input-toolbar');
+  assertIncludes(toolbarSrc, 'data-testid="attachment-select-button"', 'input-toolbar');
+  assertIncludes(toolbarSrc, 'data-testid="workspace-auto-file-write-approval-toggle"', 'input-toolbar');
+  assertIncludes(toolbarSrc, 'onClick={onSelectFolder}', 'input-toolbar');
+  assertIncludes(toolbarSrc, "onClick={() => fileInputRef.current?.click()}", 'input-toolbar');
+
+  const chatInputSrc = read('src/renderer/src/components/input/ChatInput.tsx');
+  assertIncludes(chatInputSrc, 'const maybeSetWorkspaceFromFiles = useCallback((files: File[]) => {', 'chat-input');
+  assertIncludes(chatInputSrc, 'onSelectFolder={handleSelectFolder}', 'chat-input');
+  assertIncludes(chatInputSrc, 'onSelectFiles={handleSelectFiles}', 'chat-input');
+
+  const realSrc = read('tests/real_e2e_test.cjs');
+  assertIncludes(realSrc, '[data-testid="workspace-select-button"]', 'real-e2e');
+  assertIncludes(realSrc, '[data-testid="attachment-select-button"]', 'real-e2e');
+  assertIncludes(realSrc, 'Critical 7: Session Auto-Approve + Workspace Controls', 'real-e2e');
+
+  const taskManagerSrc = read('src/renderer/src/lib/task-manager.ts');
+  assertIncludes(taskManagerSrc, "electron.fs.writeInternalFile(workspacePath, 'tasks.json'", 'task-manager');
+
+  const ipcFsSrc = read('src/main/ipc/fs.ts');
+  assertIncludes(ipcFsSrc, "'.ai-worker', 'system-workspace'", 'ipc-fs');
+  assertIncludes(ipcFsSrc, "ipcMain.handle('fs:write-internal-file'", 'ipc-fs');
+  assertIncludes(ipcFsSrc, "ipcMain.handle('fs:read-internal-file'", 'ipc-fs');
+
+  const fileSystemServiceSrc = read('src/main/services/FileSystemService.ts');
+  assertIncludes(fileSystemServiceSrc, 'private isInternalTrackingFile(filePath: string): boolean {', 'filesystem-service');
+  assertIncludes(fileSystemServiceSrc, 'if (isSafeMode && !effectiveAutoApprove && !isInternalTrackingWrite)', 'filesystem-service');
+}
+
+function testFileWriteApprovalAndSandboxHardening() {
+  const useAgentSrc = read('src/renderer/src/hooks/useAgent.ts');
+  assertIncludes(
+    useAgentSrc,
+    'fileWriteAutoApprove: activeSession?.fileWriteAutoApprove,',
+    'useAgent'
+  );
+  assertNotIncludes(
+    useAgentSrc,
+    'fileWriteAutoApprove: activeSession?.fileWriteAutoApprove === true,',
+    'useAgent'
+  );
+
+  const chatStoreSrc = read('src/renderer/src/stores/chatStore.ts');
+  assertNotIncludes(chatStoreSrc, 'fileWriteAutoApprove: false,', 'chat-store');
+
+  const fsServiceSrc = read('src/main/services/FileSystemService.ts');
+  assertNotIncludes(fsServiceSrc, 'normalized.includes(legacyWorkspaceMarker)', 'filesystem-service');
+  assertNotIncludes(fsServiceSrc, 'const isInternalPathRequested = this.isInternalTrackingFile(rawPath)', 'filesystem-service');
+  assertIncludes(fsServiceSrc, "'.ai-worker', 'system-workspace'", 'filesystem-service');
+  assertIncludes(
+    fsServiceSrc,
+    'const resolvedPath = this.resolveWorkspaceScopedTargetPath(args?.path, args?.workspacePath, name)',
+    'filesystem-service'
+  );
+
+  const mcpSrc = read('src/renderer/src/lib/mcp.ts');
+  assertIncludes(mcpSrc, 'function normalizeAbsoluteFsPath(value: string): string | null {', 'mcp');
+  assertIncludes(mcpSrc, 'function resolveFsPath(baseAbsolutePath: string, targetPath: string): string | null {', 'mcp');
+  assertIncludes(mcpSrc, 'const resolvedTargetPath = resolveFsPath(normalizedWorkspacePath, rawTargetPath);', 'mcp');
+  assertIncludes(mcpSrc, 'if (!resolvedTargetPath) {', 'mcp');
+
+  const fileReviewSrc = read('src/renderer/src/components/FileChangeReview.tsx');
+  assertIncludes(fileReviewSrc, 'const [autoApproveErrorIds, setAutoApproveErrorIds] = useState<Set<string>>(new Set())', 'file-change-review');
+  assertIncludes(fileReviewSrc, 'const autoSweepCandidates = filtered.filter(', 'file-change-review');
+  assertIncludes(fileReviewSrc, 'if (autoSweepCandidates.length === 0) {', 'file-change-review');
+}
+
 function run() {
   console.log('Running critical regression checks...');
   testAgentRuntimeDelegateParallelism();
@@ -433,6 +502,8 @@ function run() {
   testClickTextBoundedTimeoutAndFallbacks();
   testRecoverySignalLogging();
   testRealE2EIdleGating();
+  testWorkspaceSelectionAndInternalTaskTracking();
+  testFileWriteApprovalAndSandboxHardening();
   console.log('All critical regression checks passed.');
 }
 


### PR DESCRIPTION
## Summary
- implement session-scoped file write auto-approval with visible header control next to workspace selector
- keep workspace selection/file selection behavior intact and scope user file operations to selected workspace
- route internal task-plan/execution writes to hidden system workspace with internal auto-approval
- harden filesystem path containment and internal tracking-file checks to prevent traversal/bypass
- preserve global auto-approve fallback when no session override is set
- prevent auto-approve UI retry loops on failed pending writes
- add/extend regression and real e2e tests for file approval/session behavior and path hardening

## Validation
- npm run -s test:build
- npm run -s typecheck
- npm run -s lint
- npm run -s test:regression:critical
- npm run -s test:e2e:issues
- npm run -s test:e2e
- npm run -s test:e2e:real:focus (live provider; one scenario can timeout under rate limits)

## Release/Publish checks
- mac upload: npm run -s publish:mac:universal -- --yes --skip-checks --skip-build
- linux publish: npm run -s publish:linux -- --yes --skip-checks
- windows publish (cross-build override): ALLOW_UNSUPPORTED_WIN_CROSS_BUILD=1 npm run -s publish:win -- --yes --skip-checks
