### PR TITLE
fix(orchestration): resolve residual bootstrap tab leaks and orphaned tabs

### DIFF
--- a/src/renderer/src/hooks/useAgent.ts
+++ b/src/renderer/src/hooks/useAgent.ts
@@ -38,7 +38,7 @@ import { useSettingsStore } from "../stores/settingsStore";
 import { type LLMMessage } from "../lib/types";
 import { resolveWhatsAppTarget, setWhatsAppTyping, setWhatsAppPaused, getWhatsAppSystemPrompt, sendWhatsAppResponse, resolveWhatsAppMessageToLLM } from "../lib/whatsapp-integration";
 import { buildAttachmentLLMParts } from "../lib/media-utils";
-import { executeToolCall } from "../lib/mcp";
+import { executeToolCall, parseTabsFromResult } from "../lib/mcp";
 
 const LOCAL_PREFERENCE_MEMORY_KEY = "ai_worker_local_preferences_v1";
 
@@ -503,6 +503,18 @@ export function useAgent(): UseAgentReturn {
 
                 const currentProcessingCount = store._processingSessions.size;
                 if (currentProcessingCount === 0) {
+                    // Best-effort cleanup for residual bootstrap blank tab when no tasks remain.
+                    // This covers delegated/orchestrated runs where the parent runtime itself
+                    // never owned a tab, but Playwright still has one idle about:blank page.
+                    try {
+                        const tabsResult = await executeToolCall("get_tabs", {});
+                        const tabs = parseTabsFromResult(tabsResult);
+                        if (tabs.length === 1 && tabs[0].url === "about:blank") {
+                            await executeToolCall("close_tab", { tabId: tabs[0].index, force: true });
+                        }
+                    } catch (e) {
+                        console.warn("[useAgent] Residual blank-tab cleanup failed:", e);
+                    }
                     console.log('[useAgent] No active sessions. Browser stays warm; idle timer will close process if unused.');
                 } else {
                     console.log(`[useAgent] 🕒 Session complete. ${currentProcessingCount} sessions still active; browser remains available.`);

--- a/src/renderer/src/lib/agent-runtime.ts
+++ b/src/renderer/src/lib/agent-runtime.ts
@@ -27,7 +27,7 @@
 import { chat } from "./llm";
 import { LLMMessage, LLMTool, ServerInfo, type LLMResponse } from "./types";
 import { pruneContext } from "./dcp";
-import { executeToolCall, getAllTools, getServers, parseTabIdFromResult } from "./mcp";
+import { executeToolCall, getAllTools, getServers, parseTabIdFromResult, parseTabsFromResult } from "./mcp";
 import { CLIENT_TOOLS, STATEFUL_BROWSER_TOOLS } from "./client-tools";
 import type { IAgentClient } from "./agent/IAgentClient";
 import {
@@ -377,6 +377,16 @@ export class AgentRuntime implements IAgentClient {
     if (this.activeTabId !== undefined) return;
 
     try {
+      // Reuse the bootstrap blank tab when it's the only tab.
+      // This avoids creating an extra "orphan" blank tab per task run.
+      const tabsResult = await executeToolCall("get_tabs", {});
+      const tabs = parseTabsFromResult(tabsResult);
+      if (tabs.length === 1 && tabs[0].url === "about:blank") {
+        this.activeTabId = tabs[0].index;
+        console.log(`[AgentRuntime] Claimed existing bootstrap tab ${tabs[0].index} for agent run`);
+        return;
+      }
+
       const tabResult = await executeToolCall("new_tab", { url: "about:blank" });
       const tabId = parseTabIdFromResult(tabResult);
       if (tabId !== undefined) {

--- a/src/renderer/src/lib/mcp.ts
+++ b/src/renderer/src/lib/mcp.ts
@@ -525,6 +525,55 @@ export function parseTabIdFromResult(toolResult: { result: unknown }): number | 
   return undefined;
 }
 
+type ParsedTab = {
+  index: number;
+  title?: string;
+  url?: string;
+  active?: boolean;
+};
+
+/**
+ * Parses tab lists from a `get_tabs` tool result.
+ * Supports both MCP content envelope and raw object result.
+ */
+export function parseTabsFromResult(toolResult: { result: unknown }): ParsedTab[] {
+  const resAny = toolResult.result as Record<string, unknown> | null | undefined;
+
+  const normalize = (value: unknown): ParsedTab[] => {
+    if (!value || typeof value !== "object") return [];
+    const tabs = (value as { tabs?: unknown[] }).tabs;
+    if (!Array.isArray(tabs)) return [];
+    return tabs
+      .map((tab) => {
+        if (!tab || typeof tab !== "object") return null;
+        const t = tab as Record<string, unknown>;
+        const index = typeof t.index === "number" ? t.index : undefined;
+        if (index === undefined) return null;
+        return {
+          index,
+          title: typeof t.title === "string" ? t.title : undefined,
+          url: typeof t.url === "string" ? t.url : undefined,
+          active: typeof t.active === "boolean" ? t.active : undefined,
+        };
+      })
+      .filter((tab): tab is ParsedTab => tab !== null);
+  };
+
+  // Primary path: MCP content envelope
+  if (resAny?.content && Array.isArray(resAny.content) && (resAny.content[0] as Record<string, unknown>)?.text) {
+    try {
+      const parsed = JSON.parse((resAny.content[0] as Record<string, unknown>).text as string);
+      const tabs = normalize(parsed);
+      if (tabs.length > 0) return tabs;
+    } catch {
+      // ignore and fall through
+    }
+  }
+
+  // Fallback: raw object
+  return normalize(resAny);
+}
+
 export async function setAutoConnect(serverId: string, enabled: boolean): Promise<void> {
   return useMcpStore.getState().setAutoConnect(serverId, enabled);
 }


### PR DESCRIPTION
## Summary
Fixes residual bootstrap tab leaks where Playwright accumulates idle `about:blank` tabs across agent runs.

## Changes
- **`mcp.ts`**: Added `parseTabsFromResult` utility to parse `get_tabs` tool results (follows same pattern as existing `parseTabIdFromResult`)
- **`agent-runtime.ts`**: Reuses existing single bootstrap `about:blank` tab instead of creating a new orphan tab per task run
- **`useAgent.ts`**: Best-effort cleanup of residual blank tabs in the finally block when all sessions complete (`_processingSessions.size === 0`)

## Design
- All changes are defensive and wrapped in try/catch — failures are logged but never fatal
- Tab reuse check is strict: only claims when exactly 1 tab exists and it's `about:blank`
- Cleanup only runs when zero sessions are active — no risk of closing another session's tab

## Validation
- `tsc --noEmit`: Clean
- `test:regression:critical`: All passed
- `test:e2e:real`: Core scenarios pass; timeouts attributed to OpenRouter rate limits